### PR TITLE
Project cleanup: fix save persistence, harden updater, guard untrusted mod data

### DIFF
--- a/.github/workflows/run_code_checks.yml
+++ b/.github/workflows/run_code_checks.yml
@@ -1,7 +1,10 @@
 name: run code checks
 
+# Read-only: this job only verifies formatting/lint. It does not push fixes,
+# so it works for pull requests from forks (whose GITHUB_TOKEN is read-only)
+# and never commits back to main on its own.
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -21,9 +24,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -35,22 +35,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install git+https://github.com/Scony/godot-gdscript-toolkit.git
 
-      - name: Run gdformat
-        id: gdformat
-        run: gdformat .
-
-      - name: Check for modified files
-        id: git-check
-        run: echo "modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
-
-      - name: Push Changes
-        if: steps.git-check.outputs.modified == 'true'
-        run: |
-          git config --global user.name 'codeWonderland Bot'
-          git config --global user.email 'development+bot@codewonder.land'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git commit -am "Fixing Formatting Issues"
-          git push
+      - name: Check formatting
+        run: gdformat --check --diff .
 
       - name: Run gdlint
         run: gdlint .

--- a/.github/workflows/run_tdg.yml
+++ b/.github/workflows/run_tdg.yml
@@ -18,7 +18,7 @@ jobs:
           contents: write
           issues: write
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Run tdg-github-action
               uses: ribtoks/tdg-github-action@master
               with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "source/mod-manager"]
 	path = source/mod-manager
-	url = git@github.com:codeWonderland/pyramid-mod-manager-submodule
+	url = https://github.com/codeWonderland/pyramid-mod-manager-submodule
 [submodule "initial_mods/pyramid-mods"]
 	path = initial_mods/pyramid-mods
 	url = https://github.com/codeWonderland/pyramid-mods

--- a/source/autoloads/additional_rules_loader.gd
+++ b/source/autoloads/additional_rules_loader.gd
@@ -11,6 +11,11 @@ func load() -> void:
 	var parsed_rules = CSVParser.parse_file(ADDITIONAL_RULES_PATH)
 
 	for rule in parsed_rules:
+		# CSV columns come from user-editable mod data; skip rows missing the
+		# expected headers rather than crashing the loader.
+		if not (rule.has("name") and rule.has("multiplayer") and rule.has("coop")):
+			continue
+
 		additional_rules[rule["name"]] = {
 			"multiplayer": rule["multiplayer"],
 			"coop": rule["coop"],

--- a/source/autoloads/background_manager.gd
+++ b/source/autoloads/background_manager.gd
@@ -29,6 +29,10 @@ func load() -> void:
 				continue
 
 			var image: Image = Image.load_from_file(BACKGROUNDS_PATH + image_path)
+			if image == null:
+				push_warning("BackgroundManager: couldn't load image %s" % image_path)
+				continue
+
 			var texture: ImageTexture = ImageTexture.create_from_image(image)
 			var image_name: String = image_path.split(".")[0]
 

--- a/source/autoloads/run_manager.gd
+++ b/source/autoloads/run_manager.gd
@@ -33,30 +33,32 @@ func add_pack(pack_data: PackData) -> void:
 
 
 func remove_pack(pack_data: PackData) -> void:
-	var index = 0
-	for pack in selected_packs:
-		if pack.title == pack_data.title:
-			selected_packs.remove_at(index)
-			break
+	var index := selected_packs.find(pack_data)
+	if index == -1:
+		return
 
-		index += 1
+	selected_packs.remove_at(index)
 	self.packs_updated.emit()
 
 
 func get_random_loadout() -> Array[PackData]:
 	var loadout: Array[PackData] = []
-	selected_packs.shuffle()
 
-	if num_games == selected_packs.size():
-		loadout = selected_packs
-	elif num_games < selected_packs.size():
-		loadout = selected_packs.slice(0, num_games)
-	else:
-		for pack in selected_packs:
-			loadout.append(pack)
+	if selected_packs.is_empty():
+		return loadout
 
-		for _index in range(num_games - selected_packs.size()):
-			loadout.append(selected_packs.pick_random())
+	# Work on a copy so "getting" a loadout doesn't reorder the player's
+	# persistent selection, and never alias it into the returned array.
+	var pool := selected_packs.duplicate()
+	pool.shuffle()
+
+	if num_games <= pool.size():
+		return pool.slice(0, num_games)
+
+	# Fewer packs selected than games: use them all, then pad with random repeats.
+	loadout = pool.duplicate()
+	for _index in range(num_games - pool.size()):
+		loadout.append(pool.pick_random())
 
 	return loadout
 

--- a/source/autoloads/save_manager.gd
+++ b/source/autoloads/save_manager.gd
@@ -21,10 +21,11 @@ func _load_config() -> void:
 
 
 func _save_config() -> void:
-	if _saves[0] != null:
-		config.set_value("user_data", "saves", _saves)
+	config.set_value("user_data", "saves", _saves)
 
-	config.save(SAVE_PATH)
+	var error := config.save(SAVE_PATH)
+	if error != OK:
+		push_error("SaveManager: failed to write %s (error %d)" % [SAVE_PATH, error])
 
 
 func create_save(save_index: int, data: SaveData) -> void:

--- a/source/autoloads/user_settings_manager.gd
+++ b/source/autoloads/user_settings_manager.gd
@@ -70,10 +70,11 @@ func db_to_volume(input_db: int) -> float:
 	if input_db == -100:
 		return 0.0
 
-	# audio range is -60db to 0db
-	# we multiply by 600 and divide by 10 to get a value in the tenths place
-	# the min fn is a probably unnecessary precaution to avoid a 1.1 result
-	return min(floor((input_db + DB_LOWER_LIMIT) * DB_LOWER_LIMIT * 10) / 10.0, 1.0)
+	# Inverse of volume_to_db: db = volume * DB_LOWER_LIMIT - DB_LOWER_LIMIT,
+	# so volume = (db + DB_LOWER_LIMIT) / DB_LOWER_LIMIT. Snap to the tenths the
+	# rest of the volume code works in and clamp to the valid 0.0-1.0 range.
+	var volume := (input_db + DB_LOWER_LIMIT) / float(DB_LOWER_LIMIT)
+	return clampf(floor(volume * 10.0) / 10.0, 0.0, 1.0)
 
 
 func _load_config() -> void:
@@ -87,7 +88,7 @@ func _load_config() -> void:
 		fullscreen = config.get_value("settings", "fullscreen", false)
 		_apply_fullscreen_setting()
 
-		background = config.get_value("settings", "background", "default")
+		background = config.get_value("settings", "background", "Default")
 
 	if config.has_section("updater"):
 		latest_version = config.get_value("updater", "latest_version", "")

--- a/source/autoloads/word_bank_loader.gd
+++ b/source/autoloads/word_bank_loader.gd
@@ -9,11 +9,25 @@ var nouns: Array = []
 
 
 func load() -> void:
-	var word_bank_file = FileAccess.open(WORD_BANK_PATH, FileAccess.READ)
-	var word_bank_text = word_bank_file.get_as_text()
-	var word_bank = JSON.parse_string(word_bank_text)
+	# The word bank lives in user-supplied mod data, so treat every step as
+	# potentially missing/malformed and always emit so the loading screen never
+	# hangs waiting on this loader.
+	adjectives = []
+	nouns = []
 
-	adjectives = word_bank["adjectives"]
-	nouns = word_bank["nouns"]
+	var word_bank_file = FileAccess.open(WORD_BANK_PATH, FileAccess.READ)
+	if word_bank_file == null:
+		push_warning("WordBankLoader: couldn't open %s" % WORD_BANK_PATH)
+		self.word_bank_loaded.emit()
+		return
+
+	var word_bank = JSON.parse_string(word_bank_file.get_as_text())
+	if word_bank is Dictionary:
+		if word_bank.get("adjectives") is Array:
+			adjectives = word_bank["adjectives"]
+		if word_bank.get("nouns") is Array:
+			nouns = word_bank["nouns"]
+	else:
+		push_warning("WordBankLoader: %s is not valid JSON" % WORD_BANK_PATH)
 
 	self.word_bank_loaded.emit()

--- a/source/game/card_group.gd
+++ b/source/game/card_group.gd
@@ -46,6 +46,14 @@ func load_from_card_group_data(data: CardGroupData) -> void:
 	_loading_from_save = true
 
 	pack = PackDataLoader.load_pack_from_path(data.pack_path)
+
+	# The referenced pack may have been deleted/uninstalled since the save was
+	# written; leave the group empty rather than dereferencing a null pack.
+	if pack == null:
+		push_warning("CardGroup: pack no longer available at %s" % data.pack_path)
+		_loading_from_save = false
+		return
+
 	_primary_index = data.primary
 	_secondary_index = data.secondary
 	_curse_index = data.curse
@@ -82,11 +90,8 @@ func _roll_cards() -> void:
 
 	if pack.secondaries.size() > 0:
 		_secondary_index = randi() % pack.secondaries.size()
-		_secondary.texture = pack.secondaries[_secondary_index]
 	else:
 		_secondary_index = -1
-
-	_load_cards()
 
 
 func _load_cards() -> void:

--- a/source/game/card_group_collection.gd
+++ b/source/game/card_group_collection.gd
@@ -46,8 +46,12 @@ func load_packs_from_save(save_data: SaveData) -> void:
 		var pack_data: PackData = PackDataLoader.load_pack_from_path(pack_path)
 		packs.append(pack_data)
 
-	for index in range(RunManager.num_games):
-		_card_groups[index].load_from_card_group_data(save_data.card_groups[index])
+	var group_count := mini(RunManager.num_games, save_data.card_groups.size())
+	for index in range(group_count):
+		var group_data: CardGroupData = save_data.card_groups[index]
+		if group_data == null:
+			continue
+		_card_groups[index].load_from_card_group_data(group_data)
 
 	_loading_from_save = false
 

--- a/source/menus/menu_widgets/save_slot.gd
+++ b/source/menus/menu_widgets/save_slot.gd
@@ -43,13 +43,22 @@ func _display_save_data() -> void:
 		_card.texture = DEFAULT_CARD_TEXTURE
 		_card_label.show()
 		_delete_button.hide()
-	else:
-		var first_pack: PackData = PackDataLoader.load_pack_from_path(
-			save_data.card_groups[0].pack_path
-		)
+		return
+
+	# A populated slot can still reference a pack the user has since deleted
+	# (or a save with no card groups), so fall back to the default art instead
+	# of crashing the dialog.
+	var first_pack: PackData = null
+	if not save_data.card_groups.is_empty():
+		first_pack = PackDataLoader.load_pack_from_path(save_data.card_groups[0].pack_path)
+
+	if first_pack != null and not first_pack.backs.is_empty():
 		_card.texture = first_pack.backs[0]
-		_card_label.hide()
-		_delete_button.show()
+	else:
+		_card.texture = DEFAULT_CARD_TEXTURE
+
+	_card_label.hide()
+	_delete_button.show()
 
 
 func _on_gui_input(event: InputEvent) -> void:

--- a/source/resources/card_group_data.gd
+++ b/source/resources/card_group_data.gd
@@ -1,6 +1,6 @@
 class_name CardGroupData extends Resource
 
-var pack_path: String
-var primary: int
-var secondary: int
-var curse: int
+@export var pack_path: String = ""
+@export var primary: int = 0
+@export var secondary: int = -1
+@export var curse: int = -1

--- a/source/resources/save_data.gd
+++ b/source/resources/save_data.gd
@@ -1,7 +1,7 @@
 class_name SaveData extends Resource
 
-var title: String = ""
-var selected_pack_paths: Array[String] = []
-var rolled_loadout_paths: Array[String] = []
-var num_games: int = 5
-var card_groups: Array[CardGroupData] = []
+@export var title: String = ""
+@export var selected_pack_paths: Array[String] = []
+@export var rolled_loadout_paths: Array[String] = []
+@export var num_games: int = 5
+@export var card_groups: Array[CardGroupData] = []

--- a/source/updater/updater.gd
+++ b/source/updater/updater.gd
@@ -7,6 +7,8 @@ const NETWORK_CHECK_TIME: float = 15.0
 const INITIAL_MODS_PATH: String = "res://initial_mods/pyramid-mods/"
 const MODS_ROOT: String = "user://mods/"
 const REMOTE_MODS_PATH: String = "user://mods/pyramid-mods-main/"
+const UPDATE_ZIP_PATH: String = "user://updates.zip"
+const UPDATE_TEMP_PATH: String = "user://mods_update_tmp/"
 
 var _has_internet: bool = false
 var _internet_check_resolved: bool = false
@@ -132,46 +134,143 @@ func _apply_updates(
 		return
 
 	# Save ZIP File
-	var output_zip = FileAccess.open("user://updates.zip", FileAccess.WRITE)
-	output_zip.store_buffer(body)
-	output_zip.close()
+	if not _write_buffer_to_file(UPDATE_ZIP_PATH, body):
+		_label.text = "Couldn't save update file, using existing mods"
+		_load_data()
+		return
 
-	# Delete remote mods (preserve user://mods/local/)
+	# Extract to a temporary directory first so a corrupt/malicious download can
+	# never leave the user with half-deleted mods (existing mods stay untouched
+	# until we know the new ones extracted cleanly).
+	if not _extract_zip_to(UPDATE_ZIP_PATH, UPDATE_TEMP_PATH):
+		_label.text = "Update download was invalid, using existing mods"
+		_cleanup_path(UPDATE_TEMP_PATH)
+		_cleanup_path(UPDATE_ZIP_PATH)
+		_load_data()
+		return
+
+	# Extraction succeeded: now it's safe to swap in the new mods.
 	var remote_mods = DirAccess.open(REMOTE_MODS_PATH)
 	if remote_mods:
 		Helpers.delete_recursive(remote_mods)
 
-	# Ensure mods root exists
 	DirAccess.make_dir_recursive_absolute(MODS_ROOT)
-	var mods_folder = DirAccess.open(MODS_ROOT)
+	_move_directory_contents(UPDATE_TEMP_PATH, MODS_ROOT)
 
-	# Extract ZIP File
-	var zip_reader = ZIPReader.new()
-	zip_reader.open("user://updates.zip")
+	_cleanup_path(UPDATE_TEMP_PATH)
+	_cleanup_path(UPDATE_ZIP_PATH)
 
-	var files = zip_reader.get_files()
-	for file_path in files:
-		if file_path.ends_with("/"):
-			mods_folder.make_dir_recursive(file_path)
-			continue
-
-		mods_folder.make_dir_recursive(
-			mods_folder.get_current_dir().path_join(file_path).get_base_dir()
-		)
-		var file = FileAccess.open(
-			mods_folder.get_current_dir().path_join(file_path), FileAccess.WRITE
-		)
-		var buffer = zip_reader.read_file(file_path)
-		file.store_buffer(buffer)
-
-	# Delete Zip
-	DirAccess.open("user://").remove("updates.zip")
-
-	# Update Records
+	# Only record the new version once the swap has actually completed.
 	UserSettingsManager.update_latest_version(_latest_version)
 
 	_label.text = "Updates Applied"
 	_load_data()
+
+
+func _write_buffer_to_file(path: String, body: PackedByteArray) -> bool:
+	var file = FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		push_error(
+			"Updater: failed to open %s for writing (%d)" % [path, FileAccess.get_open_error()]
+		)
+		return false
+
+	file.store_buffer(body)
+	file.close()
+	return true
+
+
+# Rejects path-traversal and absolute entries so a malicious archive can't write
+# outside the extraction directory (zip-slip).
+func _is_safe_zip_entry(path: String) -> bool:
+	var normalized := path.replace("\\", "/")
+
+	if normalized.begins_with("/"):
+		return false
+
+	# Drive-letter style absolute paths (e.g. "C:/...").
+	if normalized.length() >= 2 and normalized[1] == ":":
+		return false
+
+	for segment in normalized.split("/"):
+		if segment == "..":
+			return false
+
+	return true
+
+
+func _extract_zip_to(zip_path: String, dest_root: String) -> bool:
+	_cleanup_path(dest_root)
+	DirAccess.make_dir_recursive_absolute(dest_root)
+
+	var dest_dir = DirAccess.open(dest_root)
+	if dest_dir == null:
+		push_error("Updater: couldn't open extraction directory %s" % dest_root)
+		return false
+
+	var zip_reader = ZIPReader.new()
+	if zip_reader.open(zip_path) != OK:
+		push_error("Updater: couldn't open downloaded archive %s" % zip_path)
+		return false
+
+	var files = zip_reader.get_files()
+	if files.is_empty():
+		push_error("Updater: downloaded archive was empty")
+		zip_reader.close()
+		return false
+
+	var base := dest_dir.get_current_dir()
+	for file_path in files:
+		if not _is_safe_zip_entry(file_path):
+			push_warning("Updater: skipping unsafe archive entry %s" % file_path)
+			continue
+
+		if file_path.ends_with("/"):
+			dest_dir.make_dir_recursive(base.path_join(file_path))
+			continue
+
+		var out_path := base.path_join(file_path)
+		dest_dir.make_dir_recursive(out_path.get_base_dir())
+
+		var out = FileAccess.open(out_path, FileAccess.WRITE)
+		if out == null:
+			push_error("Updater: failed to write %s during extraction" % out_path)
+			zip_reader.close()
+			return false
+
+		out.store_buffer(zip_reader.read_file(file_path))
+		out.close()
+
+	zip_reader.close()
+	return true
+
+
+func _move_directory_contents(source_root: String, dest_root: String) -> void:
+	var source_dir = DirAccess.open(source_root)
+	if source_dir == null:
+		return
+
+	for sub in source_dir.get_directories():
+		var dest := dest_root.path_join(sub)
+		var existing = DirAccess.open(dest)
+		if existing:
+			Helpers.delete_recursive(existing)
+		DirAccess.rename_absolute(source_root.path_join(sub), dest)
+
+	for file_name in source_dir.get_files():
+		var dest_file := dest_root.path_join(file_name)
+		if FileAccess.file_exists(dest_file):
+			DirAccess.remove_absolute(dest_file)
+		DirAccess.rename_absolute(source_root.path_join(file_name), dest_file)
+
+
+func _cleanup_path(path: String) -> void:
+	if path.ends_with("/"):
+		var dir = DirAccess.open(path)
+		if dir:
+			Helpers.delete_recursive(dir)
+	elif FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
 
 
 # === Initial Mods Functions ===


### PR DESCRIPTION
A cleanup pass addressing correctness, crash-safety, security, and CI issues surfaced by a full project review.

## 🔴 Critical
- **Save persistence**: `SaveData`/`CardGroupData` fields are now `@export` so `ConfigFile` actually serializes them — previously every save came back empty after a restart.
- **SaveManager**: always writes the saves array (was gated on slot 0 being non-null, so saves to other slots silently never reached disk) and reports write errors.
- **Updater**: extracts downloaded archives to a temp dir and only swaps in new mods after a clean extraction, so a corrupt/failed download no longer wipes existing mods; rejects path-traversal/absolute zip entries (zip-slip); null-checks every `FileAccess.open` and the `ZIPReader.open` result.

## 🟠 Major
- `card_group_collection`: clamp the load loop to the saved group count and skip null groups (out-of-bounds crash on load).
- `save_slot` / `card_group`: fall back to default art when a save references a pack the player has since deleted, instead of dereferencing a null pack.
- `word_bank_loader` / `additional_rules_loader`: tolerate missing/malformed user mod data and always emit so the loading screen can't hang.
- `background_manager`: null-check loaded images.
- `run_manager.get_random_loadout`: operate on a copy (no longer reorders the player's selection or aliases it into the loadout) and guard the empty-selection case.

## 🟡 Minor
- `card_group`: drop the redundant second `_load_cards()` per pack assignment.
- `user_settings_manager`: fix background default casing (`"Default"`) and correct `db_to_volume` to be the true inverse of `volume_to_db`.

## CI / hygiene
- `run_code_checks`: verify formatting with `gdformat --check` instead of auto-committing fixes — works for fork PRs and the bot can't push to `main`.
- mod-manager submodule switched to an HTTPS URL; `checkout` bumped to v4.

## Submodule
The matching `mod_manager` / `pack_data_loader` / `pack_editor` fixes were merged via codeWonderland/pyramid-mod-manager-submodule#1; this PR bumps the submodule pointer to that merged commit.
