### PR TITLE
Draggable challenge cards with velocity-based tilt

### DIFF
--- a/source/game/card_tilt.gdshader
+++ b/source/game/card_tilt.gdshader
@@ -1,0 +1,32 @@
+shader_type canvas_item;
+
+// Fakes a 3D pitch/roll lean on a flat 2D card by rotating its quad's corners
+// in 3D and applying a perspective divide. Driven from challenge_card.gd while
+// the card is being dragged to give a "wind resistance" feel.
+//
+// pitch: lean about the horizontal (X) axis  — top/bottom tips toward/away
+// roll:  lean about the vertical (Y) axis     — left/right tips toward/away
+
+uniform vec2 card_size = vec2(105.0, 150.0);
+uniform float pitch = 0.0;
+uniform float roll = 0.0;
+uniform float perspective = 0.0020;
+
+void vertex() {
+	vec2 center = card_size * 0.5;
+	vec3 p = vec3(VERTEX - center, 0.0);
+
+	// Roll about the Y axis.
+	float cr = cos(roll);
+	float sr = sin(roll);
+	p = vec3(p.x * cr + p.z * sr, p.y, -p.x * sr + p.z * cr);
+
+	// Pitch about the X axis.
+	float cp = cos(pitch);
+	float sp = sin(pitch);
+	p = vec3(p.x, p.y * cp - p.z * sp, p.y * sp + p.z * cp);
+
+	// Perspective: corners pushed away (negative z) shrink, nearer ones grow.
+	float w = 1.0 / (1.0 - p.z * perspective);
+	VERTEX = p.xy * w + center;
+}

--- a/source/game/card_tilt.gdshader.uid
+++ b/source/game/card_tilt.gdshader.uid
@@ -1,0 +1,1 @@
+uid://d1b535xmwahfc

--- a/source/game/challenge_card.gd
+++ b/source/game/challenge_card.gd
@@ -8,6 +8,16 @@ const DRAG_THRESHOLD: float = 6.0
 ## z_index used while dragging so the card floats above its siblings.
 const DRAG_Z_INDEX: int = 10
 
+# Velocity-based tilt: drag velocity (px/sec) maps to a pitch/roll lean.
+const TILT_SHADER: Shader = preload("res://source/game/card_tilt.gdshader")
+## Radians of lean per px/sec of drag velocity (sign flips the lean direction).
+const ROLL_PER_VELOCITY: float = 0.0004
+const PITCH_PER_VELOCITY: float = 0.0004
+## Hard cap on the lean so a fast flick stays believable (radians).
+const MAX_TILT: float = 0.4
+## How quickly the current lean chases its target (higher = snappier).
+const TILT_RESPONSE: float = 14.0
+
 @export var is_curse: bool = false
 @export var accounting_for_curse: bool = false
 
@@ -20,11 +30,45 @@ var _press_global_position: Vector2 = Vector2.ZERO
 # so the point we grabbed stays under the cursor for the whole drag.
 var _grab_offset: Vector2 = Vector2.ZERO
 
+# Mouse motion accumulated since the last _process frame, converted to a
+# velocity there so a stationary hold naturally flattens the card back out.
+var _frame_motion: Vector2 = Vector2.ZERO
+var _pitch: float = 0.0
+var _roll: float = 0.0
+var _tilt_material: ShaderMaterial
+
 
 func _ready() -> void:
+	_setup_tilt_material()
 	_resize()
 	get_tree().get_root().size_changed.connect(_resize)
 	gui_input.connect(_on_gui_input)
+
+
+func _setup_tilt_material() -> void:
+	_tilt_material = ShaderMaterial.new()
+	_tilt_material.shader = TILT_SHADER
+	material = _tilt_material
+
+
+func _process(delta: float) -> void:
+	# Convert this frame's accumulated motion into a velocity (zero when the
+	# card is held still or not being dragged), then ease the lean toward it.
+	var velocity := _frame_motion / maxf(delta, 0.0001)
+	_frame_motion = Vector2.ZERO
+
+	var target_roll := 0.0
+	var target_pitch := 0.0
+	if _dragging:
+		target_roll = clampf(velocity.x * ROLL_PER_VELOCITY, -MAX_TILT, MAX_TILT)
+		target_pitch = clampf(velocity.y * PITCH_PER_VELOCITY, -MAX_TILT, MAX_TILT)
+
+	var weight := clampf(delta * TILT_RESPONSE, 0.0, 1.0)
+	_roll = lerpf(_roll, target_roll, weight)
+	_pitch = lerpf(_pitch, target_pitch, weight)
+
+	_tilt_material.set_shader_parameter("roll", _roll)
+	_tilt_material.set_shader_parameter("pitch", _pitch)
 
 
 func _physics_process(_delta: float) -> void:
@@ -94,6 +138,7 @@ func _input(event: InputEvent) -> void:
 
 		if _dragging:
 			position = get_parent().get_local_mouse_position() + _grab_offset
+			_frame_motion += event.relative
 			get_viewport().set_input_as_handled()
 	elif (
 		event is InputEventMouseButton
@@ -133,3 +178,7 @@ func _resize() -> void:
 	custom_minimum_size = Vector2(card_size.x * scale_mult, card_size.y * scale_mult)
 	size = custom_minimum_size
 	pivot_offset = Vector2(size.x / 2, size.y / 2)
+
+	# Keep the tilt shader's quad dimensions in sync with the on-screen size.
+	if _tilt_material != null:
+		_tilt_material.set_shader_parameter("card_size", size)

--- a/source/game/challenge_card.gd
+++ b/source/game/challenge_card.gd
@@ -12,7 +12,7 @@ const DRAG_Z_INDEX: int = 10
 const TILT_SHADER: Shader = preload("res://source/game/card_tilt.gdshader")
 ## Radians of lean per px/sec of drag velocity (sign flips the lean direction).
 const ROLL_PER_VELOCITY: float = 0.0004
-const PITCH_PER_VELOCITY: float = 0.0004
+const PITCH_PER_VELOCITY: float = -0.0004
 ## Hard cap on the lean so a fast flick stays believable (radians).
 const MAX_TILT: float = 0.4
 ## How quickly the current lean chases its target (higher = snappier).

--- a/source/game/challenge_card.gd
+++ b/source/game/challenge_card.gd
@@ -2,10 +2,23 @@ class_name ChallengeCard extends TextureRect
 
 signal pressed
 
+## Pixels the pointer must travel while held before a press becomes a drag.
+## Below this, releasing counts as a click (which re-rolls the card).
+const DRAG_THRESHOLD: float = 6.0
+## z_index used while dragging so the card floats above its siblings.
+const DRAG_Z_INDEX: int = 10
+
 @export var is_curse: bool = false
 @export var accounting_for_curse: bool = false
 
 var hovering: bool = false
+
+var _pressed: bool = false
+var _dragging: bool = false
+var _press_global_position: Vector2 = Vector2.ZERO
+# Parent-local offset between the card's position and the mouse at grab time,
+# so the point we grabbed stays under the cursor for the whole drag.
+var _grab_offset: Vector2 = Vector2.ZERO
 
 
 func _ready() -> void:
@@ -15,6 +28,11 @@ func _ready() -> void:
 
 
 func _physics_process(_delta: float) -> void:
+	# While dragging, position and z_index are driven by the drag; skip the hover
+	# logic so it doesn't fight for control of either.
+	if _dragging:
+		return
+
 	var local_mouse_pos := get_local_mouse_position()
 	var mouse_over_card := Rect2(Vector2.ZERO, size).has_point(local_mouse_pos)
 
@@ -49,7 +67,58 @@ func _physics_process(_delta: float) -> void:
 
 
 func _on_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.is_pressed():
+	# Begin a potential click/drag on left-press. Motion and release are handled
+	# in _input() so we keep receiving events even when the cursor leaves the
+	# card's rect during a fast drag.
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.pressed:
+			if RunManager.popup_open:
+				return
+			_pressed = true
+			_dragging = false
+			_press_global_position = event.global_position
+			_grab_offset = position - get_parent().get_local_mouse_position()
+			accept_event()
+
+
+func _input(event: InputEvent) -> void:
+	if not _pressed:
+		return
+
+	if event is InputEventMouseMotion:
+		if (
+			not _dragging
+			and event.global_position.distance_to(_press_global_position) > DRAG_THRESHOLD
+		):
+			_begin_drag()
+
+		if _dragging:
+			position = get_parent().get_local_mouse_position() + _grab_offset
+			get_viewport().set_input_as_handled()
+	elif (
+		event is InputEventMouseButton
+		and event.button_index == MOUSE_BUTTON_LEFT
+		and not event.pressed
+	):
+		_end_press()
+
+
+func _begin_drag() -> void:
+	_dragging = true
+	z_index = DRAG_Z_INDEX
+
+
+func _end_press() -> void:
+	var was_dragging := _dragging
+	_pressed = false
+	_dragging = false
+
+	if was_dragging:
+		# Drop the card where it was released; let the hover loop reclaim z_index.
+		z_index = 0
+		get_viewport().set_input_as_handled()
+	else:
+		# A click with no drag re-rolls the card (preserves the old behavior).
 		self.pressed.emit()
 
 


### PR DESCRIPTION
Makes the drafted challenge cards in the game scene click-and-draggable, with a velocity-based pitch/roll lean for a "wind resistance" feel.

## Drag
- Left-press + move past a 6px threshold → drag; the card follows the cursor and floats above its siblings (`z_index`).
- Left-press + release without moving → re-rolls the card (the original click behavior, moved from press to release).
- Motion/release run in `_input()` so a fast drag keeps tracking when the cursor leaves the card's rect; the hover loop yields position/`z_index` control while dragging. Dragging is blocked while a popup is open.

## Velocity-based tilt (pitch/roll)
- `card_tilt.gdshader` — a `canvas_item` vertex shader that fakes a 3D lean by rotating the card's quad in pitch/roll with a perspective divide (identity at rest).
- `challenge_card.gd` accumulates pointer motion per frame, converts it to a velocity, and eases the lean toward a clamped, velocity-proportional target — leaning into motion and springing back flat on stop/release.
- Tunables at the top of `challenge_card.gd`: `*_PER_VELOCITY` (gain; sign flips the axis), `MAX_TILT`, `TILT_RESPONSE`; plus `perspective` in the shader.

### Known limitations (first pass)
- Cards stay where dropped; no snap-back. A window resize re-runs `CardGroup._resize()`, which can reposition the secondary/curse cards.
- Cross-card-group stacking isn't specially handled (uses `z_index`, no reparenting/`top_level`).
- The tilt uses a 4-corner affine warp, so very steep angles read as shear rather than true perspective — fine for subtle leans.
