### PR TITLE
Exclude addons/ from TODO-ticket scanning

### DIFF
--- a/.github/workflows/run_tdg.yml
+++ b/.github/workflows/run_tdg.yml
@@ -27,3 +27,6 @@ jobs:
                   SHA: ${{ github.sha }}
                   REF: ${{ github.ref }}
                   LABEL: "TODO Ticket"
+                  # Don't file tickets for TODOs inside vendored third-party
+                  # code (e.g. the GUT testing addon).
+                  EXCLUDE_PATTERN: "addons/.*"


### PR DESCRIPTION
Vendoring the GUT testing addon (#20) caused the `tdg-github-action` to auto-file ~8 `TODO Ticket` issues (#21–#28) for GUT's *own* internal TODO comments (all under `addons/gut/`).

This scopes the action with `EXCLUDE_PATTERN: "addons/.*"` so third-party/vendored code no longer generates issues. Once merged, the action's next run on `main` should close the stale GUT tickets automatically (any stragglers will be closed manually).
