### PR TITLE
Pack search and tag filtering for the draft screen (#38)

### DIFF
--- a/source/autoloads/packs_manager.gd
+++ b/source/autoloads/packs_manager.gd
@@ -26,3 +26,23 @@ func load() -> void:
 	all_packs.sort_custom(PackDataLoader.sort_packs)
 
 	self.packs_loaded.emit()
+
+
+## Every distinct tag declared by the loaded packs, for building filter lists.
+## De-duplicated case-insensitively (keeping the first spelling seen) and sorted
+## so the filter panel's checkbox order is stable between runs.
+func all_tags() -> Array[String]:
+	var seen := {}
+	var tags: Array[String] = []
+
+	for pack in all_packs:
+		for tag in pack.tags:
+			var key := tag.to_lower()
+			if seen.has(key):
+				continue
+
+			seen[key] = true
+			tags.append(tag)
+
+	tags.sort_custom(func(a: String, b: String) -> bool: return a.naturalnocasecmp_to(b) < 0)
+	return tags

--- a/source/menus/menu_widgets/pack_filter_panel.gd
+++ b/source/menus/menu_widgets/pack_filter_panel.gd
@@ -1,0 +1,164 @@
+class_name PackFilterPanel extends Control
+
+## Tag filter drawer for the draft screen. Slides in from the right edge with a
+## checkbox per tag declared by the loaded packs, an any/all mode toggle, and a
+## search box for when the tag list grows long.
+
+signal filters_changed(tags: Array[String], match_all: bool)
+
+## Panel width at the 1920x1080 reference size; scaled to fit smaller screens.
+const REFERENCE_WIDTH: float = 420.0
+const SLIDE_TIME: float = 0.25
+
+var _match_all: bool = false
+var _tag_search: String = ""
+# Ticked tags, keyed by their lowercased form so the set survives packs that
+# spell the same tag differently.
+var _selected: Dictionary = {}
+var _checkboxes: Array[CheckBox] = []
+var _slide_tween: Tween = null
+
+@onready var _mode_button: Button = %ModeButton
+@onready var _search: LineEdit = %TagSearch
+@onready var _tag_list: VBoxContainer = %TagList
+@onready var _clear_button: Button = %ClearButton
+@onready var _empty_label: Label = %EmptyLabel
+
+
+func _ready() -> void:
+	_resize()
+	get_tree().get_root().size_changed.connect(_resize)
+
+	_mode_button.pressed.connect(_toggle_mode)
+	_search.text_changed.connect(_on_tag_search_changed)
+	_clear_button.pressed.connect(clear_filters)
+
+	_update_mode_label()
+	rebuild()
+	_snap_closed()
+
+
+## True while the drawer is showing.
+func is_open() -> bool:
+	return offset_left < 0.0
+
+
+func toggle() -> void:
+	if is_open():
+		close()
+	else:
+		open()
+
+
+func open() -> void:
+	_slide_to(-_panel_width())
+
+
+func close() -> void:
+	_slide_to(0.0)
+
+
+func clear_filters() -> void:
+	_selected.clear()
+	for box in _checkboxes:
+		box.set_pressed_no_signal(false)
+	_emit_change()
+
+
+## Rebuilds the checkbox list from the loaded packs. Safe to call again after
+## packs reload; ticked tags that still exist stay ticked.
+func rebuild() -> void:
+	for child in _tag_list.get_children():
+		child.queue_free()
+	_checkboxes = []
+
+	var tags := PacksManager.all_tags()
+	_empty_label.visible = tags.is_empty()
+
+	for tag in tags:
+		var box := CheckBox.new()
+		box.text = tag
+		box.set_pressed_no_signal(_selected.has(tag.to_lower()))
+		box.toggled.connect(_on_tag_toggled.bind(tag))
+		_tag_list.add_child(box)
+		_checkboxes.append(box)
+
+	_apply_tag_search()
+
+
+func selected_tags() -> Array[String]:
+	var tags: Array[String] = []
+	for box in _checkboxes:
+		if box.button_pressed:
+			tags.append(box.text)
+	return tags
+
+
+func _panel_width() -> float:
+	var viewport_width := get_viewport().size.x as float
+	return minf(REFERENCE_WIDTH * (viewport_width / 1920.0), viewport_width)
+
+
+## Re-anchors the drawer for the new viewport width, keeping it on whichever
+## side it was already on. Any in-flight slide is dropped: its targets were
+## computed against the old width.
+func _resize() -> void:
+	var width := _panel_width()
+	var was_open := is_open()
+
+	if _slide_tween != null and _slide_tween.is_valid():
+		_slide_tween.kill()
+
+	offset_left = -width if was_open else 0.0
+	offset_right = 0.0 if was_open else width
+
+
+func _snap_closed() -> void:
+	var width := _panel_width()
+	offset_left = 0.0
+	offset_right = width
+
+
+func _slide_to(target_left: float) -> void:
+	var width := _panel_width()
+
+	if _slide_tween != null and _slide_tween.is_valid():
+		_slide_tween.kill()
+
+	_slide_tween = create_tween().set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC)
+	_slide_tween.parallel().tween_property(self, "offset_left", target_left, SLIDE_TIME)
+	_slide_tween.parallel().tween_property(self, "offset_right", target_left + width, SLIDE_TIME)
+
+
+func _toggle_mode() -> void:
+	_match_all = not _match_all
+	_update_mode_label()
+	_emit_change()
+
+
+func _update_mode_label() -> void:
+	_mode_button.text = "Match: All" if _match_all else "Match: Any"
+
+
+func _on_tag_toggled(pressed: bool, tag: String) -> void:
+	if pressed:
+		_selected[tag.to_lower()] = true
+	else:
+		_selected.erase(tag.to_lower())
+	_emit_change()
+
+
+func _on_tag_search_changed(query: String) -> void:
+	_tag_search = query
+	_apply_tag_search()
+
+
+## Hides checkboxes that don't match the in-panel search. A ticked tag stays
+## visible so the player can always see and undo what is filtering the grid.
+func _apply_tag_search() -> void:
+	for box in _checkboxes:
+		box.visible = box.button_pressed or FuzzyMatch.matches(_tag_search, box.text)
+
+
+func _emit_change() -> void:
+	self.filters_changed.emit(selected_tags(), _match_all)

--- a/source/menus/menu_widgets/pack_filter_panel.gd.uid
+++ b/source/menus/menu_widgets/pack_filter_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://b6jb0qcb72trd

--- a/source/menus/menu_widgets/pack_filter_panel.tscn
+++ b/source/menus/menu_widgets/pack_filter_panel.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=2 format=3 uid="uid://cq1p8vn3xk4wa"]
+
+[ext_resource type="Script" uid="uid://b6jb0qcb72trd" path="res://source/menus/menu_widgets/pack_filter_panel.gd" id="1_pfp01"]
+
+[node name="PackFilterPanel" type="Control" unique_id=1174330001]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_right = 420.0
+grow_horizontal = 0
+script = ExtResource("1_pfp01")
+
+[node name="Backing" type="PanelContainer" parent="." unique_id=1174330002]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Margin" type="MarginContainer" parent="Backing" unique_id=1174330003]
+layout_mode = 2
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 24
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 24
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Backing/Margin" unique_id=1174330004]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="Backing/Margin/VBoxContainer" unique_id=1174330005]
+layout_mode = 2
+text = "Filters"
+theme_type_variation = &"MediumTitle"
+
+[node name="ModeButton" type="Button" parent="Backing/Margin/VBoxContainer" unique_id=1174330006]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Match: Any"
+
+[node name="TagSearch" type="LineEdit" parent="Backing/Margin/VBoxContainer" unique_id=1174330007]
+unique_name_in_owner = true
+layout_mode = 2
+placeholder_text = "Search filters..."
+clear_button_enabled = true
+
+[node name="EmptyLabel" type="Label" parent="Backing/Margin/VBoxContainer" unique_id=1174330008]
+unique_name_in_owner = true
+layout_mode = 2
+text = "No packs declare tags yet."
+autowrap_mode = 2
+theme_type_variation = &"SmallLabel"
+
+[node name="TagScroll" type="ScrollContainer" parent="Backing/Margin/VBoxContainer" unique_id=1174330009]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+
+[node name="TagList" type="VBoxContainer" parent="Backing/Margin/VBoxContainer/TagScroll" unique_id=1174330010]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ClearButton" type="Button" parent="Backing/Margin/VBoxContainer" unique_id=1174330011]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Clear filters"

--- a/source/menus/menu_widgets/pack_select_packs.gd
+++ b/source/menus/menu_widgets/pack_select_packs.gd
@@ -17,6 +17,11 @@ const PACK_SELECT_CARD: PackedScene = preload(
 var _current_page: int = 0
 var _sort_ascending: bool = true
 var _favorites_only: bool = false
+var _search_query: String = ""
+var _tag_filters: Array[String] = []
+# With more than one tag ticked: true requires a pack to carry all of them,
+# false requires only one of them.
+var _match_all_tags: bool = false
 
 
 func _ready() -> void:
@@ -34,6 +39,20 @@ func set_sort_ascending(ascending: bool) -> void:
 
 func set_favorites_only(favorites_only: bool) -> void:
 	_favorites_only = favorites_only
+	_current_page = 0
+	_populate()
+
+
+func set_search_query(query: String) -> void:
+	_search_query = query
+	_current_page = 0
+	_populate()
+
+
+## Tag filters from the filter panel. `match_all` picks AND over OR.
+func set_tag_filters(tags: Array[String], match_all: bool) -> void:
+	_tag_filters = tags.duplicate()
+	_match_all_tags = match_all
 	_current_page = 0
 	_populate()
 
@@ -110,6 +129,10 @@ func _ordered_packs() -> Array[PackData]:
 		var favorite := FavoritesManager.is_favorite(pack.folder_path)
 		if _favorites_only and not favorite:
 			continue
+		if not FuzzyMatch.matches(_search_query, pack.title):
+			continue
+		if not _matches_tag_filters(pack):
+			continue
 		if favorite:
 			favorites.append(pack)
 		else:
@@ -119,6 +142,27 @@ func _ordered_packs() -> Array[PackData]:
 	ordered.append_array(favorites)
 	ordered.append_array(others)
 	return ordered
+
+
+## No ticked tags means the tag filter is off, so every pack passes.
+func _matches_tag_filters(pack: PackData) -> bool:
+	if _tag_filters.is_empty():
+		return true
+
+	# Compare case-insensitively: the ticked tag and the pack's spelling of it
+	# can differ between packs.
+	var pack_tags := {}
+	for tag in pack.tags:
+		pack_tags[tag.to_lower()] = true
+
+	for wanted in _tag_filters:
+		var has := pack_tags.has(wanted.to_lower())
+		if _match_all_tags and not has:
+			return false
+		if not _match_all_tags and has:
+			return true
+
+	return _match_all_tags
 
 
 func _get_card_size() -> Vector2:

--- a/source/menus/pack_select.gd
+++ b/source/menus/pack_select.gd
@@ -14,6 +14,9 @@ var _favorites_only: bool = false
 @onready var _done: Button = %Done
 @onready var _sort_button: Button = %SortButton
 @onready var _filter_button: Button = %FilterButton
+@onready var _search_bar: LineEdit = %SearchBar
+@onready var _tag_filter_button: Button = %TagFilterButton
+@onready var _filter_panel: PackFilterPanel = %PackFilterPanel
 
 
 func _ready() -> void:
@@ -24,6 +27,10 @@ func _ready() -> void:
 	_done.pressed.connect(_selection_complete)
 	_sort_button.pressed.connect(_toggle_sort)
 	_filter_button.pressed.connect(_toggle_filter)
+	_search_bar.text_changed.connect(_on_search_changed)
+	_tag_filter_button.pressed.connect(_toggle_filter_panel)
+	_filter_panel.filters_changed.connect(_on_tag_filters_changed)
+	PacksManager.packs_loaded.connect(_filter_panel.rebuild)
 	_pack_select_packs.pack_added.connect(RunManager.add_pack)
 	_pack_select_selected_packs.pack_pressed.connect(RunManager.remove_pack)
 
@@ -51,6 +58,21 @@ func _toggle_filter() -> void:
 	_favorites_only = not _favorites_only
 	_update_filter_labels()
 	_pack_select_packs.set_favorites_only(_favorites_only)
+
+
+func _on_search_changed(query: String) -> void:
+	_pack_select_packs.set_search_query(query)
+
+
+func _toggle_filter_panel() -> void:
+	if _pause_menu.visible:
+		return
+
+	_filter_panel.toggle()
+
+
+func _on_tag_filters_changed(tags: Array[String], match_all: bool) -> void:
+	_pack_select_packs.set_tag_filters(tags, match_all)
 
 
 func _set_background() -> void:

--- a/source/menus/pack_select.tscn
+++ b/source/menus/pack_select.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://f2wi86f1h7bp" path="res://assets/sprites/ui/buttons/settings.png" id="4_lqhju"]
 [ext_resource type="PackedScene" uid="uid://ild1rgpwgs05" path="res://source/menus/menu_widgets/pack_select_packs.tscn" id="5_lqhju"]
 [ext_resource type="PackedScene" uid="uid://b545m6djvjs8k" path="res://source/menus/menu_widgets/pack_select_selected_packs.tscn" id="6_u4vdn"]
+[ext_resource type="PackedScene" uid="uid://cq1p8vn3xk4wa" path="res://source/menus/menu_widgets/pack_filter_panel.tscn" id="9_pfp01"]
 [ext_resource type="PackedScene" uid="uid://bhjmr1eb57wwh" path="res://source/menus/pause_menu.tscn" id="10_gnfts"]
 
 [node name="PackSelect" type="Control" unique_id=594107462]
@@ -48,21 +49,29 @@ layout_mode = 0
 offset_bottom = 76.0
 texture_normal = ExtResource("3_wx4qi")
 
-[node name="Label" type="Label" parent="MarginContainer/TitleBar" unique_id=24256238]
+[node name="SearchBar" type="LineEdit" parent="MarginContainer/TitleBar" unique_id=1174340001]
+unique_name_in_owner = true
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -133.5
-offset_top = -38.0
-offset_right = 133.5
-offset_bottom = 38.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_type_variation = &"BigTitle"
-text = "Select Packs"
+anchors_preset = 10
+anchor_right = 1.0
+offset_left = 90.0
+offset_top = 8.0
+offset_right = -180.0
+offset_bottom = 68.0
+placeholder_text = "Search packs..."
+clear_button_enabled = true
+
+[node name="TagFilterButton" type="Button" parent="MarginContainer/TitleBar" unique_id=1174340002]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -172.0
+offset_top = 8.0
+offset_right = -84.0
+offset_bottom = 68.0
+text = "Filters"
 
 [node name="Pause" type="TextureButton" parent="MarginContainer/TitleBar" unique_id=1125449630]
 unique_name_in_owner = true
@@ -180,6 +189,9 @@ offset_bottom = -12.0
 grow_horizontal = 0
 grow_vertical = 0
 text = "Filter: All"
+
+[node name="PackFilterPanel" parent="." unique_id=1174340003 instance=ExtResource("9_pfp01")]
+unique_name_in_owner = true
 
 [node name="PauseMenu" parent="." unique_id=1954334397 instance=ExtResource("10_gnfts")]
 unique_name_in_owner = true

--- a/source/util/fuzzy_match.gd
+++ b/source/util/fuzzy_match.gd
@@ -1,0 +1,32 @@
+class_name FuzzyMatch
+
+## Subsequence matching for the draft screen's search box: a query matches when
+## all of its characters appear in the text in order, though not necessarily
+## next to each other. So "tboi" finds "The Binding of Isaac" and "isaac" finds
+## it too, without the player having to type a title exactly.
+##
+## Matching is case-insensitive and used purely as a filter — ranking is left to
+## the screen's own sort so search never fights the chosen A-Z/Z-A order.
+
+
+## True when every character of `query` appears in `text` in order. An empty or
+## whitespace-only query matches everything, so clearing the box shows all packs.
+static func matches(query: String, text: String) -> bool:
+	var needle := query.strip_edges().to_lower()
+	if needle.is_empty():
+		return true
+
+	var haystack := text.to_lower()
+	if needle.length() > haystack.length():
+		return false
+
+	var needle_index := 0
+	for haystack_index in range(haystack.length()):
+		if haystack[haystack_index] != needle[needle_index]:
+			continue
+
+		needle_index += 1
+		if needle_index == needle.length():
+			return true
+
+	return false

--- a/source/util/fuzzy_match.gd.uid
+++ b/source/util/fuzzy_match.gd.uid
@@ -1,0 +1,1 @@
+uid://ddhqk12atfred

--- a/test/unit/test_fuzzy_match.gd
+++ b/test/unit/test_fuzzy_match.gd
@@ -1,0 +1,42 @@
+extends GutTest
+
+# Tests FuzzyMatch.matches(), the subsequence matcher behind the draft screen's
+# search box.
+
+
+func test_empty_query_matches_everything() -> void:
+	assert_true(FuzzyMatch.matches("", "The Binding of Isaac"), "empty query matches")
+	assert_true(FuzzyMatch.matches("   ", "The Binding of Isaac"), "whitespace query matches")
+
+
+func test_exact_and_substring_match() -> void:
+	assert_true(FuzzyMatch.matches("isaac", "The Binding of Isaac"), "substring matches")
+	assert_true(
+		FuzzyMatch.matches("The Binding of Isaac", "The Binding of Isaac"), "full title matches"
+	)
+
+
+func test_case_insensitive() -> void:
+	assert_true(FuzzyMatch.matches("ISAAC", "The Binding of Isaac"), "upper query matches")
+	assert_true(FuzzyMatch.matches("isaac", "THE BINDING OF ISAAC"), "upper text matches")
+
+
+func test_initials_style_subsequence() -> void:
+	assert_true(FuzzyMatch.matches("tboi", "The Binding of Isaac"), "initials match in order")
+	assert_true(FuzzyMatch.matches("bind", "The Binding of Isaac"), "prefix of a word matches")
+
+
+func test_order_matters() -> void:
+	assert_false(FuzzyMatch.matches("iobt", "The Binding of Isaac"), "out-of-order does not match")
+
+
+func test_absent_characters_do_not_match() -> void:
+	assert_false(FuzzyMatch.matches("zzz", "The Binding of Isaac"), "absent characters fail")
+
+
+func test_query_longer_than_text_does_not_match() -> void:
+	assert_false(FuzzyMatch.matches("a very long query indeed", "Isaac"), "too-long query fails")
+
+
+func test_leading_and_trailing_whitespace_is_ignored() -> void:
+	assert_true(FuzzyMatch.matches("  isaac  ", "The Binding of Isaac"), "query is trimmed")

--- a/test/unit/test_fuzzy_match.gd.uid
+++ b/test/unit/test_fuzzy_match.gd.uid
@@ -1,0 +1,1 @@
+uid://brfuviiq6mar0

--- a/test/unit/test_pack_data_loader.gd
+++ b/test/unit/test_pack_data_loader.gd
@@ -2,6 +2,8 @@ extends GutTest
 
 # Tests for source/mod-manager PackDataLoader (submodule code).
 
+var _tag_root: String
+
 
 func test_sort_packs_orders_by_title() -> void:
 	var a := PackData.new()
@@ -17,3 +19,87 @@ func test_missing_pack_path_returns_null() -> void:
 	var pack = PackDataLoader.load_pack_from_path("user://definitely_missing_%d" % randi())
 
 	assert_null(pack, "a pack folder with no card backs loads as null, not a crash")
+
+
+# --- Pack metadata / tags ---
+
+
+func before_each() -> void:
+	_tag_root = "user://test_packtags_%d" % randi()
+	DirAccess.make_dir_recursive_absolute(_tag_root)
+
+
+func after_each() -> void:
+	var dir = DirAccess.open(_tag_root)
+	if dir:
+		Helpers.delete_recursive(dir)
+
+
+func _write_metadata(contents: String) -> void:
+	var file := FileAccess.open(_tag_root.path_join(PackDataLoader.METADATA_FILE), FileAccess.WRITE)
+	file.store_string(contents)
+	file.close()
+
+
+func test_no_metadata_file_means_no_tags() -> void:
+	assert_eq(PackDataLoader.load_tags(_tag_root), [], "a pack without pack.json has no tags")
+
+
+func test_reads_tag_list() -> void:
+	_write_metadata('{"tags": ["Roguelike", "Deckbuilder"]}')
+
+	assert_eq(
+		PackDataLoader.load_tags(_tag_root),
+		["Roguelike", "Deckbuilder"],
+		"tags load in the order the pack author wrote them"
+	)
+
+
+func test_malformed_json_warns_and_yields_no_tags() -> void:
+	_write_metadata("{not json at all")
+
+	assert_eq(PackDataLoader.load_tags(_tag_root), [], "broken JSON degrades to no tags")
+
+
+func test_non_object_json_yields_no_tags() -> void:
+	_write_metadata('["Roguelike"]')
+
+	assert_eq(PackDataLoader.load_tags(_tag_root), [], "a bare JSON array is not valid metadata")
+
+
+func test_non_list_tags_yields_no_tags() -> void:
+	_write_metadata('{"tags": "Roguelike"}')
+
+	assert_eq(PackDataLoader.load_tags(_tag_root), [], "a string tags field degrades to no tags")
+
+
+func test_missing_tags_key_is_not_an_error() -> void:
+	_write_metadata('{"author": "someone"}')
+
+	assert_eq(PackDataLoader.load_tags(_tag_root), [], "metadata without tags is still valid")
+
+
+func test_skips_blank_and_non_string_entries() -> void:
+	_write_metadata('{"tags": ["Roguelike", "", "   ", 7, null, "Deckbuilder"]}')
+
+	assert_eq(
+		PackDataLoader.load_tags(_tag_root),
+		["Roguelike", "Deckbuilder"],
+		"blank and non-string entries are dropped"
+	)
+
+
+func test_trims_whitespace() -> void:
+	_write_metadata('{"tags": ["  Roguelike  "]}')
+
+	assert_eq(PackDataLoader.load_tags(_tag_root), ["Roguelike"], "tags are trimmed")
+
+
+func test_deduplicates_case_insensitively_keeping_first_spelling() -> void:
+	_write_metadata('{"tags": ["Roguelike", "roguelike", "ROGUELIKE", "Deckbuilder"]}')
+
+	assert_eq(
+		PackDataLoader.load_tags(_tag_root),
+		["Roguelike", "Deckbuilder"],
+		"case variants collapse to the first spelling the author used"
+	)

--- a/test/unit/test_pack_filter_panel.gd
+++ b/test/unit/test_pack_filter_panel.gd
@@ -1,0 +1,150 @@
+extends GutTest
+
+# Tests the draft screen's tag filter drawer: it builds a checkbox per declared
+# tag, announces selection changes, searches its own list, and slides open/shut.
+
+const FILTER_PANEL: PackedScene = preload("res://source/menus/menu_widgets/pack_filter_panel.tscn")
+
+var _saved_all_packs: Array[PackData]
+
+
+func _pack(title: String, tags: Array[String]) -> PackData:
+	var pack := PackData.new()
+	pack.title = title
+	pack.folder_path = "user://__test_panel_%s" % title
+	pack.tags = tags
+	return pack
+
+
+func before_each() -> void:
+	_saved_all_packs = PacksManager.all_packs
+	var packs: Array[PackData] = [
+		_pack("A", ["Roguelike", "Deckbuilder"] as Array[String]),
+		_pack("B", ["Metroidvania"] as Array[String]),
+	]
+	PacksManager.all_packs = packs
+
+
+func after_each() -> void:
+	PacksManager.all_packs = _saved_all_packs
+
+
+func _make_panel() -> PackFilterPanel:
+	var panel := FILTER_PANEL.instantiate() as PackFilterPanel
+	add_child_autofree(panel)
+	await get_tree().process_frame
+	return panel
+
+
+func _box_for(panel: PackFilterPanel, tag: String) -> CheckBox:
+	for box in panel._checkboxes:
+		if box.text == tag:
+			return box
+	return null
+
+
+func test_builds_a_checkbox_per_tag_sorted() -> void:
+	var panel := await _make_panel()
+
+	var labels: Array = []
+	for box in panel._checkboxes:
+		labels.append(box.text)
+
+	assert_eq(labels, ["Deckbuilder", "Metroidvania", "Roguelike"], "one sorted checkbox per tag")
+
+
+func test_shows_empty_notice_when_no_pack_declares_tags() -> void:
+	PacksManager.all_packs = [_pack("A", [] as Array[String])] as Array[PackData]
+
+	var panel := await _make_panel()
+
+	assert_eq(panel._checkboxes.size(), 0, "no checkboxes without tags")
+	assert_true(panel._empty_label.visible, "the empty notice is shown instead")
+
+
+func test_ticking_a_tag_emits_selection() -> void:
+	var panel := await _make_panel()
+	watch_signals(panel)
+
+	_box_for(panel, "Roguelike").button_pressed = true
+
+	assert_signal_emitted(panel, "filters_changed")
+	assert_eq(panel.selected_tags(), ["Roguelike"], "the ticked tag is reported")
+
+
+func test_mode_button_toggles_any_all() -> void:
+	var panel := await _make_panel()
+
+	assert_eq(panel._mode_button.text, "Match: Any", "starts in Any mode")
+
+	panel._mode_button.pressed.emit()
+	assert_eq(panel._mode_button.text, "Match: All", "switches to All")
+
+	panel._mode_button.pressed.emit()
+	assert_eq(panel._mode_button.text, "Match: Any", "switches back to Any")
+
+
+func test_mode_change_reports_match_all() -> void:
+	var panel := await _make_panel()
+	var seen_match_all := [false]
+	panel.filters_changed.connect(func(_tags, match_all): seen_match_all[0] = match_all)
+
+	panel._mode_button.pressed.emit()
+
+	assert_true(seen_match_all[0], "switching to All reports match_all = true")
+
+
+func test_in_panel_search_hides_non_matching_tags() -> void:
+	var panel := await _make_panel()
+
+	panel._search.text_changed.emit("deck")
+
+	assert_true(_box_for(panel, "Deckbuilder").visible, "matching tag stays visible")
+	assert_false(_box_for(panel, "Metroidvania").visible, "non-matching tag is hidden")
+
+
+func test_in_panel_search_keeps_ticked_tags_visible() -> void:
+	var panel := await _make_panel()
+
+	_box_for(panel, "Metroidvania").button_pressed = true
+	panel._search.text_changed.emit("deck")
+
+	assert_true(
+		_box_for(panel, "Metroidvania").visible,
+		"a ticked tag stays visible so it can always be un-ticked"
+	)
+
+
+func test_clear_filters_unticks_everything() -> void:
+	var panel := await _make_panel()
+
+	_box_for(panel, "Roguelike").button_pressed = true
+	_box_for(panel, "Deckbuilder").button_pressed = true
+	assert_eq(panel.selected_tags().size(), 2, "two tags ticked")
+
+	panel.clear_filters()
+
+	assert_eq(panel.selected_tags(), [], "clear unticks every tag")
+
+
+func test_starts_closed_and_toggles_open() -> void:
+	var panel := await _make_panel()
+
+	assert_false(panel.is_open(), "the drawer starts closed")
+
+	panel.open()
+	await get_tree().create_timer(PackFilterPanel.SLIDE_TIME + 0.1).timeout
+	assert_true(panel.is_open(), "opening slides it into view")
+
+	panel.close()
+	await get_tree().create_timer(PackFilterPanel.SLIDE_TIME + 0.1).timeout
+	assert_false(panel.is_open(), "closing slides it back out")
+
+
+func test_rebuild_keeps_existing_selection() -> void:
+	var panel := await _make_panel()
+
+	_box_for(panel, "Roguelike").button_pressed = true
+	panel.rebuild()
+
+	assert_eq(panel.selected_tags(), ["Roguelike"], "a ticked tag survives a rebuild")

--- a/test/unit/test_pack_filter_panel.gd.uid
+++ b/test/unit/test_pack_filter_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://c42m55yg7uelf

--- a/test/unit/test_pack_select_filtering.gd
+++ b/test/unit/test_pack_select_filtering.gd
@@ -1,0 +1,192 @@
+extends GutTest
+
+# Tests the draft grid's search box and tag filters (#38), and that they compose
+# with the existing sort / favorites ordering rather than replacing it.
+
+const PACK_SELECT_PACKS: PackedScene = preload(
+	"res://source/menus/menu_widgets/pack_select_packs.tscn"
+)
+
+var _saved_all_packs: Array[PackData]
+
+
+func _texture() -> ImageTexture:
+	var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	return ImageTexture.create_from_image(img)
+
+
+func _path(title: String) -> String:
+	return "user://__test_filter_%s" % title
+
+
+func _pack(title: String, tags: Array[String]) -> PackData:
+	var pack := PackData.new()
+	pack.title = title
+	pack.folder_path = _path(title)
+	var backs: Array[ImageTexture] = [_texture()]
+	pack.backs = backs
+	pack.tags = tags
+	return pack
+
+
+func before_each() -> void:
+	_saved_all_packs = PacksManager.all_packs
+	var packs: Array[PackData] = [
+		_pack("The Binding of Isaac", ["Roguelike", "Twin-stick"] as Array[String]),
+		_pack("Hollow Knight", ["Metroidvania"] as Array[String]),
+		_pack("Slay the Spire", ["Roguelike", "Deckbuilder"] as Array[String]),
+		_pack("Untagged Game", [] as Array[String]),
+	]
+	PacksManager.all_packs = packs
+
+
+func after_each() -> void:
+	# Clear favorites while the test packs are still installed: restoring
+	# all_packs first would leave a test favorite set for the next test.
+	for pack in PacksManager.all_packs:
+		if FavoritesManager.is_favorite(pack.folder_path):
+			FavoritesManager.toggle(pack.folder_path)
+
+	PacksManager.all_packs = _saved_all_packs
+
+
+func _titles(packs: Array) -> Array:
+	var out: Array = []
+	for pack in packs:
+		out.append(pack.title)
+	return out
+
+
+func _make_grid() -> PackSelectPacks:
+	var grid := PACK_SELECT_PACKS.instantiate() as PackSelectPacks
+	add_child_autofree(grid)
+	await get_tree().process_frame
+	return grid
+
+
+# --- Search ---
+
+
+func test_empty_search_shows_everything() -> void:
+	var grid := await _make_grid()
+
+	grid.set_search_query("")
+	assert_eq(grid._ordered_packs().size(), 4, "an empty query filters nothing")
+
+
+func test_search_matches_substring() -> void:
+	var grid := await _make_grid()
+
+	grid.set_search_query("isaac")
+	assert_eq(_titles(grid._ordered_packs()), ["The Binding of Isaac"], "substring search")
+
+
+func test_search_matches_initials_subsequence() -> void:
+	var grid := await _make_grid()
+
+	grid.set_search_query("tboi")
+	assert_eq(_titles(grid._ordered_packs()), ["The Binding of Isaac"], "fuzzy initials search")
+
+
+func test_search_with_no_matches_is_empty() -> void:
+	var grid := await _make_grid()
+
+	grid.set_search_query("zzzzz")
+	assert_eq(grid._ordered_packs(), [], "no matches yields an empty grid, not a crash")
+
+
+func test_search_keeps_favorites_first() -> void:
+	FavoritesManager.toggle(_path("Slay the Spire"))
+	var grid := await _make_grid()
+
+	# "s" matches all four titles as a subsequence; the favorite still leads.
+	grid.set_search_query("s")
+	assert_eq(
+		_titles(grid._ordered_packs())[0], "Slay the Spire", "search preserves favorites-first"
+	)
+
+
+# --- Tag filters ---
+
+
+func test_no_tag_filter_shows_everything() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters([] as Array[String], false)
+	assert_eq(grid._ordered_packs().size(), 4, "no ticked tags filters nothing")
+
+
+func test_single_tag_filter() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["Metroidvania"] as Array[String], false)
+	assert_eq(_titles(grid._ordered_packs()), ["Hollow Knight"], "one tag narrows to one pack")
+
+
+func test_tag_filter_is_case_insensitive() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["metroidvania"] as Array[String], false)
+	assert_eq(
+		_titles(grid._ordered_packs()), ["Hollow Knight"], "tag matching ignores capitalisation"
+	)
+
+
+func test_or_mode_matches_any_ticked_tag() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["Deckbuilder", "Metroidvania"] as Array[String], false)
+	assert_eq(
+		_titles(grid._ordered_packs()),
+		["Hollow Knight", "Slay the Spire"],
+		"OR mode returns packs carrying either tag"
+	)
+
+
+func test_and_mode_requires_every_ticked_tag() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["Roguelike", "Deckbuilder"] as Array[String], true)
+	assert_eq(
+		_titles(grid._ordered_packs()),
+		["Slay the Spire"],
+		"AND mode keeps only the pack carrying both tags"
+	)
+
+
+func test_and_mode_with_no_pack_matching_all_is_empty() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["Metroidvania", "Deckbuilder"] as Array[String], true)
+	assert_eq(grid._ordered_packs(), [], "no pack carries both tags")
+
+
+func test_untagged_packs_are_excluded_by_any_tag_filter() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["Roguelike"] as Array[String], false)
+	assert_false(
+		_titles(grid._ordered_packs()).has("Untagged Game"), "a pack with no tags cannot match"
+	)
+
+
+# --- Search and tags together ---
+
+
+func test_search_and_tag_filter_compose() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["Roguelike"] as Array[String], false)
+	grid.set_search_query("slay")
+	assert_eq(
+		_titles(grid._ordered_packs()), ["Slay the Spire"], "search narrows within the tag filter"
+	)
+
+
+func test_search_and_tag_filter_can_intersect_to_nothing() -> void:
+	var grid := await _make_grid()
+
+	grid.set_tag_filters(["Metroidvania"] as Array[String], false)
+	grid.set_search_query("isaac")
+	assert_eq(grid._ordered_packs(), [], "contradictory search and tag filter yields nothing")

--- a/test/unit/test_pack_select_filtering.gd.uid
+++ b/test/unit/test_pack_select_filtering.gd.uid
@@ -1,0 +1,1 @@
+uid://c1t2gu83haeem

--- a/test/unit/test_pack_select_layout.gd
+++ b/test/unit/test_pack_select_layout.gd
@@ -20,3 +20,38 @@ func test_draft_screen_builds_and_restructures() -> void:
 		screen._pack_select_selected_packs.get_parent() is ScrollContainer,
 		"selected-packs strip lives in a scroll view"
 	)
+
+
+# --- Search + filter panel wiring (#38) ---
+
+
+func test_search_bar_and_filter_controls_resolve() -> void:
+	var screen := PACK_SELECT.instantiate() as PackSelect
+	add_child_autofree(screen)
+	await get_tree().process_frame
+
+	assert_true(is_instance_valid(screen._search_bar), "search bar resolved")
+	assert_true(is_instance_valid(screen._tag_filter_button), "filters button resolved")
+	assert_true(is_instance_valid(screen._filter_panel), "filter panel resolved")
+	assert_false(screen._filter_panel.is_open(), "the filter drawer starts closed")
+
+
+func test_typing_in_the_search_bar_filters_the_grid() -> void:
+	var screen := PACK_SELECT.instantiate() as PackSelect
+	add_child_autofree(screen)
+	await get_tree().process_frame
+
+	screen._search_bar.text_changed.emit("zzzzz-no-such-pack")
+
+	assert_eq(screen._pack_select_packs._ordered_packs(), [], "an unmatched query empties the grid")
+
+
+func test_filters_button_opens_the_drawer() -> void:
+	var screen := PACK_SELECT.instantiate() as PackSelect
+	add_child_autofree(screen)
+	await get_tree().process_frame
+
+	screen._tag_filter_button.pressed.emit()
+	await get_tree().create_timer(PackFilterPanel.SLIDE_TIME + 0.1).timeout
+
+	assert_true(screen._filter_panel.is_open(), "the Filters button slides the drawer open")

--- a/test/unit/test_packs_manager_tags.gd
+++ b/test/unit/test_packs_manager_tags.gd
@@ -1,0 +1,76 @@
+extends GutTest
+
+# Tests PacksManager.all_tags(), which feeds the draft screen's filter list:
+# distinct tags across every loaded pack, case-insensitively de-duplicated and
+# sorted for a stable checkbox order.
+
+var _saved_all_packs: Array[PackData]
+
+
+func _pack(title: String, tags: Array[String]) -> PackData:
+	var pack := PackData.new()
+	pack.title = title
+	pack.folder_path = "user://__test_tags_%s" % title
+	pack.tags = tags
+	return pack
+
+
+func before_each() -> void:
+	_saved_all_packs = PacksManager.all_packs
+
+
+func after_each() -> void:
+	PacksManager.all_packs = _saved_all_packs
+
+
+func _set_packs(packs: Array[PackData]) -> void:
+	PacksManager.all_packs = packs
+
+
+func test_no_packs_means_no_tags() -> void:
+	_set_packs([] as Array[PackData])
+
+	assert_eq(PacksManager.all_tags(), [], "no packs, no tags")
+
+
+func test_untagged_packs_contribute_nothing() -> void:
+	_set_packs([_pack("A", [] as Array[String])] as Array[PackData])
+
+	assert_eq(PacksManager.all_tags(), [], "a pack with no tags adds nothing")
+
+
+func test_collects_across_packs_sorted() -> void:
+	_set_packs(
+		(
+			[
+				_pack("A", ["Roguelike", "Deckbuilder"] as Array[String]),
+				_pack("B", ["Metroidvania"] as Array[String]),
+			]
+			as Array[PackData]
+		)
+	)
+
+	assert_eq(
+		PacksManager.all_tags(),
+		["Deckbuilder", "Metroidvania", "Roguelike"],
+		"tags from every pack, sorted"
+	)
+
+
+func test_deduplicates_across_packs_case_insensitively() -> void:
+	_set_packs(
+		(
+			[
+				_pack("A", ["Roguelike"] as Array[String]),
+				_pack("B", ["roguelike"] as Array[String]),
+				_pack("C", ["ROGUELIKE"] as Array[String]),
+			]
+			as Array[PackData]
+		)
+	)
+
+	assert_eq(
+		PacksManager.all_tags(),
+		["Roguelike"],
+		"the same tag spelled differently collapses to the first spelling"
+	)

--- a/test/unit/test_packs_manager_tags.gd.uid
+++ b/test/unit/test_packs_manager_tags.gd.uid
@@ -1,0 +1,1 @@
+uid://c1nb8y64prwa4


### PR DESCRIPTION
Advances #38. Depends on codeWonderland/pyramid-mod-manager-submodule#3.

> [!IMPORTANT]
> **Merge order.** The submodule PR must merge first. Because it squash-merges to a new SHA, the pointer in this branch (currently the feature-branch commit `0742697`) then needs re-bumping to the submodule's new `main` SHA before this merges — otherwise `main` ends up pointing at a commit that is orphaned when the submodule branch is deleted.

## What this adds

A **search bar** across the title bar and a **Filters drawer** that slides in from the right with a checkbox per tag the loaded packs declare — the layout from the mockup on the issue.

Search is **subsequence matching**, so `tboi` finds *The Binding of Isaac* and `isaac` finds it too. It is deliberately a filter and not a ranking, so it composes with the existing A-Z / Z-A sort and favourites-first ordering rather than fighting them.

The drawer carries:
- an **Any / All** toggle for combining several tags (OR vs AND),
- its **own search box**, for when the tag list grows long — a ticked tag stays visible even when it doesn't match, so it can always be un-ticked,
- a **clear** button,
- and an empty-state notice, since no pack declares tags yet.

Both search and tag filters funnel through `_ordered_packs()`, the single place the grid already composed sort and favourites, so all four compose.

## Where tags come from

Packs declare them in the optional `pack.json` added in the submodule PR. A pack without one carries no tags and behaves exactly as before.

**Nothing populates tags yet** — the official packs in `pyramid-mods` have no `pack.json`, so the drawer shows its empty notice until content lands there. That's a separate content change in the mods repo.

## Notable decisions

- **The "Select Packs" title label makes way for the search bar**, since the mockup draws the bar across that space.
- **"Filters" is a text button**, matching the existing "Sort:" / "Filter:" buttons — there is no funnel icon in `assets/sprites/ui`. Happy to swap in art if you'd rather.
- **The existing bottom-right "Filter: All / Favorites" button stays**, as it does in the mockup; favourites remain their own control rather than becoming a tag.

## Tests

48 new tests, 55 → 103 total, all passing:

- `FuzzyMatch` — empty/whitespace queries, substring, case-insensitivity, initials-style subsequence, order sensitivity, over-long queries, trimming.
- `PacksManager.all_tags()` — no packs, untagged packs, collection across packs, case-insensitive de-duplication, sort stability.
- Grid filtering — search alone, tag filters in both Any and All modes, case-insensitive tag matching, untagged packs excluded by any tag filter, search and tags composing (including to an empty result), and search preserving favourites-first.
- The drawer — checkbox-per-tag, empty state, selection signalling, mode toggle, in-panel search (including keeping ticked tags visible), clear, open/close sliding, and selection surviving a rebuild.
- Draft screen wiring — the controls resolve, typing filters the grid, and the Filters button opens the drawer.

`gdformat` / `gdlint` clean on both repos; the submodule's standalone suite passes 13/13.