### PR TITLE
Pick up pack editor tag authoring

### DIFF
--- a/test/unit/test_pack_data_loader.gd
+++ b/test/unit/test_pack_data_loader.gd
@@ -103,3 +103,47 @@ func test_deduplicates_case_insensitively_keeping_first_spelling() -> void:
 		["Roguelike", "Deckbuilder"],
 		"case variants collapse to the first spelling the author used"
 	)
+
+
+# --- Writing metadata (save_tags) ---
+
+
+func test_save_then_load_round_trips() -> void:
+	var tags: Array[String] = ["Roguelike", "Deckbuilder"]
+
+	assert_true(PackDataLoader.save_tags(_tag_root, tags), "save reports success")
+	assert_eq(PackDataLoader.load_tags(_tag_root), tags, "tags survive a save/load round trip")
+
+
+func test_save_writes_readable_json() -> void:
+	PackDataLoader.save_tags(_tag_root, ["Roguelike"] as Array[String])
+
+	var path := _tag_root.path_join(PackDataLoader.METADATA_FILE)
+	var json := JSON.new()
+	assert_eq(json.parse(FileAccess.get_file_as_string(path)), OK, "written file is valid JSON")
+	assert_eq(json.data, {"tags": ["Roguelike"]}, "written document has the expected shape")
+
+
+func test_saving_empty_tags_removes_the_file() -> void:
+	PackDataLoader.save_tags(_tag_root, ["Roguelike"] as Array[String])
+	var path := _tag_root.path_join(PackDataLoader.METADATA_FILE)
+	assert_true(FileAccess.file_exists(path), "metadata file written")
+
+	PackDataLoader.save_tags(_tag_root, [] as Array[String])
+
+	assert_false(FileAccess.file_exists(path), "clearing every tag removes the metadata file")
+	assert_eq(PackDataLoader.load_tags(_tag_root), [], "and the pack reads back as untagged")
+
+
+func test_saving_empty_tags_with_no_existing_file_is_safe() -> void:
+	assert_true(PackDataLoader.save_tags(_tag_root, [] as Array[String]), "no-op save succeeds")
+	assert_eq(PackDataLoader.load_tags(_tag_root), [], "still untagged")
+
+
+func test_save_overwrites_previous_tags() -> void:
+	PackDataLoader.save_tags(_tag_root, ["Roguelike", "Deckbuilder"] as Array[String])
+	PackDataLoader.save_tags(_tag_root, ["Metroidvania"] as Array[String])
+
+	assert_eq(
+		PackDataLoader.load_tags(_tag_root), ["Metroidvania"], "a later save replaces the old tags"
+	)

--- a/test/unit/test_pack_editor_tags.gd
+++ b/test/unit/test_pack_editor_tags.gd
@@ -1,0 +1,140 @@
+extends GutTest
+
+# Tests tag editing in the mod manager's pack editor (submodule UI, exercised
+# here because it needs the parent project's PopupContainer and autoloads).
+
+const PACK_EDITOR: PackedScene = preload("res://source/mod-manager/popups/pack_editor.tscn")
+
+
+func _make_editor(pack: PackData = null) -> PackEditor:
+	var editor := PACK_EDITOR.instantiate() as PackEditor
+	add_child_autofree(editor)
+	await get_tree().process_frame
+	editor.pack_data = pack
+	editor.open()
+	await get_tree().process_frame
+	return editor
+
+
+func _pack(tags: Array[String]) -> PackData:
+	var pack := PackData.new()
+	pack.title = "Test Pack"
+	pack.tags = tags
+	return pack
+
+
+func _tag_button_labels(editor: PackEditor) -> Array:
+	var labels: Array = []
+	for child in editor._tag_list.get_children():
+		labels.append(child.text)
+	return labels
+
+
+func test_adds_a_tag() -> void:
+	var editor := await _make_editor()
+
+	assert_true(editor.add_tag("Roguelike"), "a fresh tag is accepted")
+	assert_eq(editor.pack_data.tags, ["Roguelike"], "the tag lands on the pack")
+	assert_eq(_tag_button_labels(editor).size(), 1, "and gets a button in the list")
+
+
+func test_rejects_blank_tags() -> void:
+	var editor := await _make_editor()
+
+	assert_false(editor.add_tag(""), "an empty tag is rejected")
+	assert_false(editor.add_tag("   "), "a whitespace-only tag is rejected")
+	assert_eq(editor.pack_data.tags, [], "no tags were added")
+
+
+func test_trims_whitespace() -> void:
+	var editor := await _make_editor()
+
+	editor.add_tag("  Roguelike  ")
+
+	assert_eq(editor.pack_data.tags, ["Roguelike"], "the stored tag is trimmed")
+
+
+func test_rejects_duplicates_case_insensitively() -> void:
+	var editor := await _make_editor()
+
+	assert_true(editor.add_tag("Roguelike"), "first add succeeds")
+	assert_false(editor.add_tag("roguelike"), "a case variant is rejected")
+	assert_false(editor.add_tag("ROGUELIKE"), "so is another")
+	assert_eq(editor.pack_data.tags, ["Roguelike"], "only the first spelling is kept")
+
+
+func test_removes_a_tag() -> void:
+	var editor := await _make_editor()
+	editor.add_tag("Roguelike")
+	editor.add_tag("Deckbuilder")
+
+	editor.remove_tag("Roguelike")
+
+	assert_eq(editor.pack_data.tags, ["Deckbuilder"], "the named tag is removed")
+	assert_eq(_tag_button_labels(editor).size(), 1, "its button goes with it")
+
+
+func test_removing_an_unknown_tag_is_safe() -> void:
+	var editor := await _make_editor()
+	editor.add_tag("Roguelike")
+
+	editor.remove_tag("Nonexistent")
+
+	assert_eq(editor.pack_data.tags, ["Roguelike"], "removing a tag that isn't there is a no-op")
+
+
+func test_pressing_a_tag_button_removes_it() -> void:
+	var editor := await _make_editor()
+	editor.add_tag("Roguelike")
+
+	editor._tag_list.get_child(0).pressed.emit()
+
+	assert_eq(editor.pack_data.tags, [], "clicking a tag removes it")
+
+
+func test_add_button_takes_the_field_text_and_clears_it() -> void:
+	var editor := await _make_editor()
+
+	editor._tag_line_edit.text = "Roguelike"
+	editor._add_tag_button.pressed.emit()
+
+	assert_eq(editor.pack_data.tags, ["Roguelike"], "the field's text became a tag")
+	assert_eq(editor._tag_line_edit.text, "", "and the field was cleared")
+
+
+func test_rejected_tag_leaves_the_field_alone() -> void:
+	var editor := await _make_editor()
+	editor.add_tag("Roguelike")
+
+	editor._tag_line_edit.text = "roguelike"
+	editor._add_tag_button.pressed.emit()
+
+	assert_eq(
+		editor._tag_line_edit.text, "roguelike", "a rejected duplicate stays in the field to fix"
+	)
+
+
+func test_submitting_the_field_adds_the_tag() -> void:
+	var editor := await _make_editor()
+
+	editor._tag_line_edit.text = "Roguelike"
+	editor._tag_line_edit.text_submitted.emit("Roguelike")
+
+	assert_eq(editor.pack_data.tags, ["Roguelike"], "pressing enter adds the tag")
+
+
+func test_editing_an_existing_pack_shows_its_tags() -> void:
+	var editor := await _make_editor(_pack(["Roguelike", "Deckbuilder"] as Array[String]))
+
+	assert_eq(_tag_button_labels(editor).size(), 2, "existing tags each get a button")
+
+
+func test_reopening_clears_the_previous_packs_tags() -> void:
+	var editor := await _make_editor(_pack(["Roguelike"] as Array[String]))
+	assert_eq(_tag_button_labels(editor).size(), 1, "first pack's tag is shown")
+
+	editor.pack_data = _pack([] as Array[String])
+	editor.open()
+	await get_tree().process_frame
+
+	assert_eq(_tag_button_labels(editor), [], "the untagged pack shows no tag buttons")

--- a/test/unit/test_pack_editor_tags.gd.uid
+++ b/test/unit/test_pack_editor_tags.gd.uid
@@ -1,0 +1,1 @@
+uid://dl60g2niovulq


### PR DESCRIPTION
Bumps the mod-manager submodule to the merged tag-editing support (codeWonderland/pyramid-mod-manager-submodule#4), completing the loop opened by #46: packs can now have tags **authored** in the editor, not just read and filtered on.

Pointer moves `95ca61a..220d9ce`. No game code changes here — the editor lives in the submodule.

## Tests

- `test_pack_data_loader.gd` — mirrors the submodule's new `save_tags` coverage (round-trip, on-disk JSON shape, clearing tags removing the file, no-op empty save, later save replacing earlier tags), per the convention that the submodule's `test/` mirrors into `test/unit/`.
- `test_pack_editor_tags.gd` — 12 tests for the editor's tag UI. These can only live here: `PackEditor` extends the parent project's `PopupContainer`, so it doesn't compile in the submodule's standalone harness.

103 → 120 tests, all passing. `gdformat` / `gdlint` clean.