### PR TITLE
Deal the opening hand face-down with a flip-all reveal (#40)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -55,6 +55,11 @@ Escape={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+FlipCards={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 

--- a/source/game/card_group.gd
+++ b/source/game/card_group.gd
@@ -58,12 +58,12 @@ func _setup_new() -> void:
 
 
 func _deal_initial() -> void:
-	# The initial deal is just the first draw (no flip), so a run can start with
-	# a curse already revealed in the curse slot.
-	_draw_primary_card(false, false)
+	# The opening hand is dealt face-down so the whole table can be turned over
+	# at once; a curse drawn as part of it stays hidden with the rest.
+	_draw_primary_card(false, false, true)
 
 	if pack.secondaries.size() > 0:
-		_draw_secondary_card(false, false)
+		_draw_secondary_card(false, false, true)
 	else:
 		_secondary_pile.hide()
 
@@ -105,51 +105,78 @@ func _on_secondary_draw_requested(start_dragging: bool) -> void:
 	_draw_secondary_card(true, start_dragging)
 
 
-func _draw_primary_card(flip: bool, start_dragging: bool) -> void:
+func _draw_primary_card(flip: bool, start_dragging: bool, face_down: bool = false) -> void:
 	var result := _primary_deck.draw_primary()
 	if result.is_empty():
 		_primary_pile.set_remaining(0)
 		return
 
 	var primary_entry: int = result["primary"]
-	var card := _spawn_card(primary_entry, false, false, _slot_position(false), flip)
+	var card := _spawn_card(primary_entry, false, false, _slot_position(false), flip, face_down)
 	if start_dragging:
 		card.begin_drag_from_pile()
 
 	if result.has("curse"):
 		var curse_entry: int = result["curse"]
-		_reveal_curse(curse_entry)
+		_reveal_curse(curse_entry, face_down)
 
 	_primary_pile.set_remaining(_primary_deck.size())
 
 
-func _draw_secondary_card(flip: bool, start_dragging: bool) -> void:
+func _draw_secondary_card(flip: bool, start_dragging: bool, face_down: bool = false) -> void:
 	var entry := _secondary_deck.draw_secondary()
 	if entry == -1:
 		_secondary_pile.set_remaining(0)
 		return
 
-	var card := _spawn_card(entry, true, false, _slot_position(true), flip)
+	var card := _spawn_card(entry, true, false, _slot_position(true), flip, face_down)
 	if start_dragging:
 		card.begin_drag_from_pile()
 
 	_secondary_pile.set_remaining(_secondary_deck.size())
 
 
-func _reveal_curse(curse_entry: int) -> void:
+func _reveal_curse(curse_entry: int, face_down: bool = false) -> void:
 	# Only one curse is shown at a time; retire the previous one.
 	if _curse_card != null and is_instance_valid(_curse_card):
 		_table_cards.erase(_curse_card)
 		_curse_card.queue_free()
 
 	# Fly the curse from the primary pile to the curse slot.
-	var card := _spawn_card(curse_entry, false, true, _slot_position(false), true)
+	var card := _spawn_card(
+		curse_entry, false, true, _slot_position(false), not face_down, face_down
+	)
 	_curse_card = card
 
 	var fly := card.create_tween()
 	fly.tween_property(card, "position", _curse_slot_position(), CURSE_FLY_TIME).set_trans(
 		Tween.TRANS_QUAD
 	)
+
+
+## Turns every face-down card in this group face-up. Returns how many actually
+## flipped, so the table can tell whether the control had anything to do.
+func reveal_all() -> int:
+	var revealed := 0
+
+	for card in _table_cards:
+		if not is_instance_valid(card):
+			continue
+		if not card.face_down:
+			continue
+
+		card.reveal()
+		revealed += 1
+
+	return revealed
+
+
+## Whether anything in this group is still face-down.
+func has_face_down_cards() -> bool:
+	for card in _table_cards:
+		if is_instance_valid(card) and card.face_down:
+			return true
+	return false
 
 
 # --- Trash ---
@@ -174,7 +201,12 @@ func _on_card_trashed(card: ChallengeCard) -> void:
 
 
 func _spawn_card(
-	entry: int, is_secondary: bool, is_curse_card: bool, slot: Vector2, flip: bool
+	entry: int,
+	is_secondary: bool,
+	is_curse_card: bool,
+	slot: Vector2,
+	flip: bool,
+	face_down: bool = false
 ) -> ChallengeCard:
 	var card := CHALLENGE_CARD.instantiate() as ChallengeCard
 	card.is_curse = is_curse_card
@@ -187,10 +219,12 @@ func _spawn_card(
 	card.position = slot
 
 	var front := _texture_for(entry, is_secondary)
-	if flip:
+	if face_down:
+		card.set_face_down(front)
+	elif flip:
 		card.play_flip(front)
 	else:
-		card.texture = front
+		card.set_face_up(front)
 
 	card.request_trash.connect(_on_card_trashed)
 	_table_cards.append(card)
@@ -228,6 +262,7 @@ func generate_card_group_data() -> CardGroupData:
 					"curse": card.is_curse,
 					"x": card.position.x,
 					"y": card.position.y,
+					"face_down": card.face_down,
 				}
 			)
 		)
@@ -273,8 +308,11 @@ func _restore_card(saved: Dictionary) -> void:
 	var is_secondary: bool = saved.get("secondary", false)
 	var is_curse_card: bool = saved.get("curse", false)
 	var pos := Vector2(saved.get("x", 0.0), saved.get("y", 0.0))
+	# Saves predating face-down dealing have no flag; those tables were all
+	# face-up, so that is the right default for them.
+	var face_down: bool = saved.get("face_down", false)
 
-	var card := _spawn_card(entry, is_secondary, is_curse_card, pos, false)
+	var card := _spawn_card(entry, is_secondary, is_curse_card, pos, false, face_down)
 	if is_curse_card:
 		_curse_card = card
 

--- a/source/game/card_group_collection.gd
+++ b/source/game/card_group_collection.gd
@@ -26,6 +26,26 @@ func _ready() -> void:
 	_update_pack_visibility()
 
 
+## Turns every face-down card across all groups face-up, returning how many
+## flipped so the table can skip the sound/feedback when there was nothing to do.
+func reveal_all() -> int:
+	var revealed := 0
+
+	for group in _card_groups:
+		if group.pack != null:
+			revealed += group.reveal_all()
+
+	return revealed
+
+
+## Whether any group still has a face-down card.
+func has_face_down_cards() -> bool:
+	for group in _card_groups:
+		if group.pack != null and group.has_face_down_cards():
+			return true
+	return false
+
+
 func generate_card_groups_data() -> Array[CardGroupData]:
 	var card_groups_data: Array[CardGroupData] = []
 

--- a/source/game/challenge_card.gd
+++ b/source/game/challenge_card.gd
@@ -29,6 +29,11 @@ const TILT_RESPONSE: float = 14.0
 var deck_entry: int = 0
 var deck_is_secondary: bool = false
 var back_texture: Texture2D = null
+## The card's face, kept while it is showing its back so it can be flipped over
+## later. Set through set_face_down/set_face_up/play_flip rather than directly.
+var front_texture: Texture2D = null
+## True while this card is showing its back. Face-down cards still drag normally.
+var face_down: bool = false
 
 var hovering: bool = false
 
@@ -181,8 +186,34 @@ func _end_press() -> void:
 		self.request_trash.emit(self)
 
 
+## Show this card face-down, remembering its face for a later reveal. Falls back
+## to the face when the pack has no back image, so a card is never blank.
+func set_face_down(front: Texture2D) -> void:
+	front_texture = front
+	face_down = true
+	texture = back_texture if back_texture != null else front
+
+
+## Show this card face-up straight away, with no animation.
+func set_face_up(front: Texture2D) -> void:
+	front_texture = front
+	face_down = false
+	texture = front
+
+
+## Flip a face-down card over. Does nothing to a card that is already face-up,
+## so revealing the whole table twice is harmless.
+func reveal() -> void:
+	if not face_down:
+		return
+
+	play_flip(front_texture)
+
+
 ## Deal this card face-up with a quick flip (back -> front).
 func play_flip(front: Texture2D) -> void:
+	front_texture = front
+	face_down = false
 	_flipping = true
 	if back_texture != null:
 		texture = back_texture

--- a/source/game/game.gd
+++ b/source/game/game.gd
@@ -20,6 +20,7 @@ const DICE_TEXTURES = [
 @onready var _bottom_left: VBoxContainer = %BottomLeft
 @onready var _die: TextureRect = %Die
 @onready var _roll_die_button: Button = %RollDie
+@onready var _flip_cards_button: Button = %FlipCards
 @onready var _reroll_packs_button: Button = %RerollGames
 @onready var _bottom_right: VBoxContainer = %BottomRight
 @onready var _multiplayer_rules_button: Button = %MultiplayerRulesButton
@@ -40,6 +41,7 @@ func _ready() -> void:
 	_settings_button.pressed.connect(_open_settings)
 	_close_button.pressed.connect(_close_game)
 	_roll_die_button.pressed.connect(_roll_die)
+	_flip_cards_button.pressed.connect(_flip_all_cards)
 	_reroll_packs_button.pressed.connect(_reroll_packs)
 	_multiplayer_rules_button.pressed.connect(_show_multiplayer_rules)
 	_coop_rules_button.pressed.connect(_show_coop_rules)
@@ -100,6 +102,9 @@ func _setup_card_table() -> void:
 
 	add_child(TrashZone.new())
 
+	# The groups deal their cards as they are built, so ask once that has settled.
+	_update_flip_button.call_deferred()
+
 
 func _set_background() -> void:
 	if BackgroundManager.backgrounds.has(UserSettingsManager.background):
@@ -146,6 +151,28 @@ func _close_game() -> void:
 	RunManager.popup_open = true
 
 
+## The table's cards are dealt face-down, so this is the reveal. Also bound to
+## the FlipCards action, since reaching for a button breaks the moment.
+func _flip_all_cards() -> void:
+	if RunManager.popup_open:
+		return
+
+	_card_group_collection.reveal_all()
+	_update_flip_button()
+
+
+## The control only earns its place while something is still hidden.
+func _update_flip_button() -> void:
+	_flip_cards_button.visible = _card_group_collection.has_face_down_cards()
+
+
+# _unhandled_input rather than _input: a focused LineEdit (the save-name field)
+# consumes its keys first, so typing an "f" there must not flip the table.
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("FlipCards"):
+		_flip_all_cards()
+
+
 func _roll_die() -> void:
 	if RunManager.popup_open:
 		return
@@ -171,6 +198,7 @@ func _reroll_packs() -> void:
 	_card_group_collection.packs = current_packs
 
 	_resize()
+	_update_flip_button.call_deferred()
 
 
 func _show_multiplayer_rules() -> void:

--- a/source/game/game.tscn
+++ b/source/game/game.tscn
@@ -131,6 +131,11 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Roll D6"
 
+[node name="FlipCards" type="Button" parent="MarginContainer/Bottom/BottomLeft" unique_id=1174350001]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Flip All (F)"
+
 [node name="RerollGames" type="Button" parent="MarginContainer/Bottom" unique_id=1515219405]
 unique_name_in_owner = true
 layout_mode = 1

--- a/test/unit/test_card_flipping.gd
+++ b/test/unit/test_card_flipping.gd
@@ -1,0 +1,381 @@
+extends GutTest
+
+# Tests face-down dealing and the flip-all-at-once reveal (#40): the opening hand
+# is dealt face-down, one control turns the whole table over, and the face-down
+# state survives a save/load.
+
+const PACK_DIR: String = "user://test_pack_flipping"
+const CARD_GROUP_SCENE: PackedScene = preload("res://source/game/card_group.tscn")
+const CHALLENGE_CARD: PackedScene = preload("res://source/game/challenge_card.tscn")
+const GAME_SCENE: PackedScene = preload("res://source/game/game.tscn")
+
+var _saved_adjectives: Array = []
+var _saved_nouns: Array = []
+
+
+func after_each() -> void:
+	if not _saved_adjectives.is_empty() or not _saved_nouns.is_empty():
+		WordBankLoader.adjectives = _saved_adjectives
+		WordBankLoader.nouns = _saved_nouns
+	RunManager.popup_open = false
+
+
+func _texture(fill: Color = Color.WHITE) -> ImageTexture:
+	var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+	img.fill(fill)
+	return ImageTexture.create_from_image(img)
+
+
+func _make_pack() -> PackData:
+	var pack := PackData.new()
+	pack.title = "Test"
+	pack.folder_path = "user://test_pack_flipping"
+
+	var backs: Array[ImageTexture] = [_texture(Color.BLACK)]
+	var primaries: Array[ImageTexture] = [_texture(), _texture(), _texture()]
+	var secondaries: Array[ImageTexture] = [_texture(), _texture()]
+	var curses: Array[ImageTexture] = [_texture()]
+	pack.backs = backs
+	pack.primaries = primaries
+	pack.secondaries = secondaries
+	pack.curses = curses
+	return pack
+
+
+func _make_group() -> CardGroup:
+	RunManager.num_games = 1
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+	group.pack = _make_pack()
+	await get_tree().process_frame
+	return group
+
+
+func _make_card() -> ChallengeCard:
+	var card := CHALLENGE_CARD.instantiate() as ChallengeCard
+	add_child_autofree(card)
+	await get_tree().process_frame
+	return card
+
+
+# --- ChallengeCard ---
+
+
+func test_set_face_down_shows_the_back_and_remembers_the_face() -> void:
+	var card := await _make_card()
+	var back := _texture(Color.BLACK)
+	var front := _texture(Color.RED)
+	card.back_texture = back
+
+	card.set_face_down(front)
+
+	assert_true(card.face_down, "the card reports itself face-down")
+	assert_eq(card.texture, back, "it is showing its back")
+	assert_eq(card.front_texture, front, "and remembers its face for later")
+
+
+func test_set_face_down_without_a_back_falls_back_to_the_face() -> void:
+	var card := await _make_card()
+	var front := _texture(Color.RED)
+	card.back_texture = null
+
+	card.set_face_down(front)
+
+	assert_eq(card.texture, front, "a pack with no back image never leaves a blank card")
+
+
+func test_set_face_up_shows_the_face() -> void:
+	var card := await _make_card()
+	var front := _texture(Color.RED)
+
+	card.set_face_up(front)
+
+	assert_false(card.face_down, "the card is face-up")
+	assert_eq(card.texture, front, "showing its face")
+
+
+func test_reveal_flips_a_face_down_card() -> void:
+	var card := await _make_card()
+	card.back_texture = _texture(Color.BLACK)
+	var front := _texture(Color.RED)
+	card.set_face_down(front)
+
+	card.reveal()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	assert_false(card.face_down, "the card is now face-up")
+	assert_eq(card.texture, front, "and shows its face once the flip finishes")
+
+
+func test_reveal_is_a_no_op_on_a_face_up_card() -> void:
+	var card := await _make_card()
+	var front := _texture(Color.RED)
+	card.set_face_up(front)
+
+	card.reveal()
+
+	assert_false(card.face_down, "still face-up")
+	assert_eq(card.texture, front, "and its texture was left alone")
+
+
+# --- Dealing ---
+
+
+func test_opening_hand_is_dealt_face_down() -> void:
+	var group := await _make_group()
+
+	assert_gt(group._table_cards.size(), 0, "the opening hand was dealt")
+	for card in group._table_cards:
+		assert_true(card.face_down, "every dealt card starts face-down")
+
+
+func test_a_curse_in_the_opening_hand_is_also_hidden() -> void:
+	RunManager.num_games = 1
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+
+	var pack := _make_pack()
+	group.pack = pack
+	await get_tree().process_frame
+
+	# Deal again with a curse sitting directly under the top primary.
+	group._clear_table()
+	group._primary_deck.cards = [
+		CardDeck.encode_primary(0), CardDeck.encode_curse(0), CardDeck.encode_primary(1)
+	]
+	group._build_piles()
+	group._draw_primary_card(false, false, true)
+	await get_tree().process_frame
+
+	assert_not_null(group._curse_card, "a curse surfaced")
+	assert_true(group._curse_card.face_down, "and it stays hidden with the rest of the hand")
+
+
+func test_drawing_from_a_pile_during_play_deals_face_up() -> void:
+	var group := await _make_group()
+	group.reveal_all()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	group._on_primary_draw_requested(false)
+	await get_tree().process_frame
+
+	var newest: ChallengeCard = group._table_cards[group._table_cards.size() - 1]
+	assert_false(newest.face_down, "a card the player chose to draw arrives face-up")
+
+
+# --- Revealing ---
+
+
+func test_reveal_all_turns_the_table_over() -> void:
+	var group := await _make_group()
+	var dealt := group._table_cards.size()
+
+	var revealed := group.reveal_all()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	assert_eq(revealed, dealt, "every dealt card was flipped")
+	for card in group._table_cards:
+		assert_false(card.face_down, "nothing is left face-down")
+
+
+func test_reveal_all_again_flips_nothing() -> void:
+	var group := await _make_group()
+	group.reveal_all()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	assert_eq(group.reveal_all(), 0, "a second reveal has nothing to do")
+
+
+func test_has_face_down_cards_tracks_the_table() -> void:
+	var group := await _make_group()
+	assert_true(group.has_face_down_cards(), "the fresh hand is hidden")
+
+	group.reveal_all()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	assert_false(group.has_face_down_cards(), "nothing hidden once turned over")
+
+
+# --- Persistence ---
+
+
+func _write_pack_to_disk() -> void:
+	DirAccess.make_dir_recursive_absolute(PACK_DIR)
+	for stem in ["b1", "p1", "p2", "p3", "s1", "s2", "c1"]:
+		var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+		img.fill(Color.WHITE)
+		img.save_png("%s/%s.png" % [PACK_DIR, stem])
+
+
+func _remove_pack_from_disk() -> void:
+	var dir := DirAccess.open(PACK_DIR)
+	if dir == null:
+		return
+	for file_name in dir.get_files():
+		dir.remove(file_name)
+	DirAccess.remove_absolute(PACK_DIR)
+
+
+func _reload(data: CardGroupData) -> CardGroup:
+	var restored := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(restored)
+	await get_tree().process_frame
+	restored.load_from_card_group_data(data)
+	await get_tree().process_frame
+	return restored
+
+
+func test_face_down_survives_save_and_load() -> void:
+	_write_pack_to_disk()
+	RunManager.num_games = 1
+
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+	group.pack = PackDataLoader.load_pack_from_path(PACK_DIR)
+	await get_tree().process_frame
+
+	var data := group.generate_card_group_data()
+	for saved in data.table_cards:
+		assert_true(saved["face_down"], "the saved table records the cards as hidden")
+
+	var restored := await _reload(data)
+	for card in restored._table_cards:
+		assert_true(card.face_down, "a saved-then-loaded hand is still hidden")
+
+	_remove_pack_from_disk()
+
+
+func test_revealed_table_saves_and_loads_face_up() -> void:
+	_write_pack_to_disk()
+	RunManager.num_games = 1
+
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+	group.pack = PackDataLoader.load_pack_from_path(PACK_DIR)
+	await get_tree().process_frame
+	group.reveal_all()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	var restored := await _reload(group.generate_card_group_data())
+	for card in restored._table_cards:
+		assert_false(card.face_down, "a table turned over before saving loads face-up")
+
+	_remove_pack_from_disk()
+
+
+func test_saves_predating_face_down_load_face_up() -> void:
+	_write_pack_to_disk()
+	RunManager.num_games = 1
+
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+	group.pack = PackDataLoader.load_pack_from_path(PACK_DIR)
+	await get_tree().process_frame
+
+	# Strip the flag the way an older save would have stored the table.
+	var data := group.generate_card_group_data()
+	var legacy: Array[Dictionary] = []
+	for saved in data.table_cards:
+		var entry := saved.duplicate()
+		entry.erase("face_down")
+		legacy.append(entry)
+	data.table_cards = legacy
+
+	var restored := await _reload(data)
+
+	assert_gt(restored._table_cards.size(), 0, "the legacy table restored")
+	for card in restored._table_cards:
+		assert_false(card.face_down, "cards from a save with no flag come back face-up")
+
+	_remove_pack_from_disk()
+
+
+# --- Across the whole table ---
+
+
+func _make_table() -> Game:
+	# The table rolls a run name on load, and WordBankLoader is empty here
+	# because no mod data was loaded, so stand in for it.
+	_saved_adjectives = WordBankLoader.adjectives
+	_saved_nouns = WordBankLoader.nouns
+	WordBankLoader.adjectives = ["Test"]
+	WordBankLoader.nouns = ["Testing"]
+
+	RunManager.clear()
+	RunManager.num_games = 3
+	var packs: Array[PackData] = [_make_pack(), _make_pack(), _make_pack()]
+	RunManager.selected_packs = packs
+
+	var game := GAME_SCENE.instantiate() as Game
+	add_child_autofree(game)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	return game
+
+
+func _all_table_cards(game: Game) -> Array:
+	var cards: Array = []
+	for group in game._card_group_collection._card_groups:
+		if group.pack != null:
+			cards.append_array(group._table_cards)
+	return cards
+
+
+func test_the_whole_table_is_dealt_face_down() -> void:
+	var game := await _make_table()
+
+	var cards := _all_table_cards(game)
+	assert_gt(cards.size(), 0, "the table dealt cards")
+	for card in cards:
+		assert_true(card.face_down, "every group's cards start hidden")
+
+
+func test_flip_button_turns_over_every_group() -> void:
+	var game := await _make_table()
+
+	game._flip_all_cards()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	for card in _all_table_cards(game):
+		assert_false(card.face_down, "one press reveals every group at once")
+
+
+func test_flip_button_hides_once_nothing_is_left_to_flip() -> void:
+	var game := await _make_table()
+	assert_true(game._flip_cards_button.visible, "the control is offered while cards are hidden")
+
+	game._flip_all_cards()
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	assert_false(game._flip_cards_button.visible, "and goes away once the table is face-up")
+
+
+func test_hotkey_reveals_the_table() -> void:
+	var game := await _make_table()
+
+	var event := InputEventAction.new()
+	event.action = "FlipCards"
+	event.pressed = true
+	game._unhandled_input(event)
+	await get_tree().create_timer(ChallengeCard.FLIP_TIME + 0.1).timeout
+
+	for card in _all_table_cards(game):
+		assert_false(card.face_down, "the FlipCards action reveals the table too")
+
+
+func test_flip_is_ignored_while_a_popup_is_open() -> void:
+	var game := await _make_table()
+	RunManager.popup_open = true
+
+	game._flip_all_cards()
+	await get_tree().process_frame
+
+	for card in _all_table_cards(game):
+		assert_true(card.face_down, "the table stays hidden behind an open popup")
+
+	RunManager.popup_open = false

--- a/test/unit/test_card_flipping.gd.uid
+++ b/test/unit/test_card_flipping.gd.uid
@@ -1,0 +1,1 @@
+uid://b1jvkwtvo88ko


### PR DESCRIPTION
Closes #40.

The table dealt every card face-up, so a run's challenges were visible the moment the screen loaded — there was no moment of turning them over together.

## What changes

Cards now deal **face-down**, and one control turns the whole table over at once: a **Flip All (F)** button beside Roll D6, plus the `F` key.

- A **curse drawn as part of the opening hand stays hidden** with the rest of it, rather than flying to the curse slot already visible.
- **Cards drawn from a pile during play still arrive face-up** — drawing one is already a deliberate reveal, and the existing flip animation is the satisfying part of that interaction. The flip-all control still catches anything face-down whatever its origin.
- The button **hides itself** once nothing is left to flip, so it doesn't sit there dead for the rest of the run.

`ChallengeCard` now remembers its face while showing its back (`front_texture` / `face_down`), so a card can be flipped long after it was dealt. It falls back to showing its face when a pack ships no back image, rather than going blank.

## Persistence

Table entries gain a `face_down` flag. Saves written before this have no such flag and load **face-up**, which is how those tables were actually left — matching the existing rule about keeping old save shapes readable.

## Notable detail

The hotkey is handled in `_unhandled_input`, not `_input`: a focused `LineEdit` consumes its keys first, so typing an "f" into the save-name field can't flip the table.

## Tests

19 new tests, 126 → 145 total, all passing:

- `ChallengeCard` — face-down shows the back and remembers the face, the no-back-image fallback, face-up, reveal flipping a hidden card, and reveal being a no-op on a visible one.
- Dealing — the opening hand is face-down, an opening-hand curse is hidden too, and a pile draw during play arrives face-up.
- Revealing — flip-all turns the table over and reports how many it flipped, a second flip does nothing, and `has_face_down_cards` tracks the table.
- Persistence — face-down survives save/load, a revealed table loads face-up, and a save with no flag loads face-up.
- Table level — the whole multi-group table deals hidden, the button and the hotkey both reveal every group, the button hides when done, and flipping is ignored behind an open popup.

Verified by mutation: dealing face-up again fails eight assertions.

## Noted separately

The table-level tests have to stand in for `WordBankLoader` because `Game._set_title()` calls `pick_random()` on the adjective/noun arrays, which throws `Can't take value from empty array` when they're empty. `WordBankLoader` is deliberately defensive and legitimately ends up empty on missing or malformed `word_bank.json`, so a player with broken mod data would hit that on every title roll. Pre-existing and unrelated to this change, but worth a follow-up.