### PR TITLE
Survive an empty word bank when naming a run

### DIFF
--- a/source/game/game.gd
+++ b/source/game/game.gd
@@ -1,5 +1,8 @@
 class_name Game extends Control
 
+## Run name used when the mod word bank has nothing usable in it, so broken mod
+## data costs the player a flavourful title rather than the whole screen.
+const FALLBACK_TITLE: String = "The Pyramid"
 const DICE_TEXTURES = [
 	preload("res://assets/sprites/ui/icons/d1.png"),
 	preload("res://assets/sprites/ui/icons/d2.png"),
@@ -229,23 +232,32 @@ func _on_save_closed() -> void:
 
 
 func _set_title() -> void:
-	var adjective = WordBankLoader.adjectives.pick_random()
-	var noun = WordBankLoader.nouns.pick_random()
-
-	_title.text = (
-		("The {adjective} Pyramid of {noun}")
-		. format(
-			{
-				adjective = adjective,
-				noun = noun,
-			}
-		)
-	)
+	_title.text = _random_run_name()
 
 	if _title.text.length() > 45:
 		_title.theme_type_variation = &"MediumTitle"
 	else:
 		_title.theme_type_variation = &"BigTitle"
+
+
+## Rolls a run name from the mod word bank. WordBankLoader is warn-and-continue
+## by design, so a missing or malformed word_bank.json legitimately leaves it
+## empty - picking from an empty list errors out, so fall back to a plain name
+## instead. Falls back if either list is empty, since half a name reads worse
+## than none.
+func _random_run_name() -> String:
+	if WordBankLoader.adjectives.is_empty() or WordBankLoader.nouns.is_empty():
+		return FALLBACK_TITLE
+
+	return (
+		("The {adjective} Pyramid of {noun}")
+		. format(
+			{
+				adjective = WordBankLoader.adjectives.pick_random(),
+				noun = WordBankLoader.nouns.pick_random(),
+			}
+		)
+	)
 
 
 func _on_quit_confirmed() -> void:

--- a/test/unit/test_card_flipping.gd
+++ b/test/unit/test_card_flipping.gd
@@ -9,14 +9,8 @@ const CARD_GROUP_SCENE: PackedScene = preload("res://source/game/card_group.tscn
 const CHALLENGE_CARD: PackedScene = preload("res://source/game/challenge_card.tscn")
 const GAME_SCENE: PackedScene = preload("res://source/game/game.tscn")
 
-var _saved_adjectives: Array = []
-var _saved_nouns: Array = []
-
 
 func after_each() -> void:
-	if not _saved_adjectives.is_empty() or not _saved_nouns.is_empty():
-		WordBankLoader.adjectives = _saved_adjectives
-		WordBankLoader.nouns = _saved_nouns
 	RunManager.popup_open = false
 
 
@@ -299,13 +293,6 @@ func test_saves_predating_face_down_load_face_up() -> void:
 
 
 func _make_table() -> Game:
-	# The table rolls a run name on load, and WordBankLoader is empty here
-	# because no mod data was loaded, so stand in for it.
-	_saved_adjectives = WordBankLoader.adjectives
-	_saved_nouns = WordBankLoader.nouns
-	WordBankLoader.adjectives = ["Test"]
-	WordBankLoader.nouns = ["Testing"]
-
 	RunManager.clear()
 	RunManager.num_games = 3
 	var packs: Array[PackData] = [_make_pack(), _make_pack(), _make_pack()]

--- a/test/unit/test_run_name.gd
+++ b/test/unit/test_run_name.gd
@@ -1,0 +1,101 @@
+extends GutTest
+
+# Tests the run name the table rolls on load. WordBankLoader is warn-and-continue
+# by design, so a missing or malformed word_bank.json legitimately leaves it with
+# no words; rolling a name from that used to error with "Can't take value from
+# empty array" on every load and reroll.
+
+const GAME_SCENE: PackedScene = preload("res://source/game/game.tscn")
+
+var _saved_adjectives: Array = []
+var _saved_nouns: Array = []
+
+
+func _texture() -> ImageTexture:
+	var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	return ImageTexture.create_from_image(img)
+
+
+func _make_pack() -> PackData:
+	var pack := PackData.new()
+	pack.title = "Test"
+	pack.folder_path = "user://test_pack_run_name"
+	var backs: Array[ImageTexture] = [_texture()]
+	var primaries: Array[ImageTexture] = [_texture(), _texture()]
+	pack.backs = backs
+	pack.primaries = primaries
+	return pack
+
+
+func before_each() -> void:
+	_saved_adjectives = WordBankLoader.adjectives
+	_saved_nouns = WordBankLoader.nouns
+
+
+func after_each() -> void:
+	WordBankLoader.adjectives = _saved_adjectives
+	WordBankLoader.nouns = _saved_nouns
+	RunManager.popup_open = false
+
+
+func _make_table() -> Game:
+	RunManager.clear()
+	RunManager.num_games = 1
+	var packs: Array[PackData] = [_make_pack()]
+	RunManager.selected_packs = packs
+
+	var game := GAME_SCENE.instantiate() as Game
+	add_child_autofree(game)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	return game
+
+
+func test_empty_word_bank_falls_back_instead_of_erroring() -> void:
+	WordBankLoader.adjectives = []
+	WordBankLoader.nouns = []
+
+	var game := await _make_table()
+
+	assert_eq(game._title.text, Game.FALLBACK_TITLE, "an empty word bank yields the plain name")
+
+
+func test_missing_nouns_falls_back() -> void:
+	WordBankLoader.adjectives = ["Mighty"]
+	WordBankLoader.nouns = []
+
+	var game := await _make_table()
+
+	assert_eq(game._title.text, Game.FALLBACK_TITLE, "half a word bank is not half a name")
+
+
+func test_missing_adjectives_falls_back() -> void:
+	WordBankLoader.adjectives = []
+	WordBankLoader.nouns = ["Doom"]
+
+	var game := await _make_table()
+
+	assert_eq(game._title.text, Game.FALLBACK_TITLE, "the other half is no better")
+
+
+func test_a_populated_word_bank_still_rolls_a_name() -> void:
+	WordBankLoader.adjectives = ["Mighty"]
+	WordBankLoader.nouns = ["Doom"]
+
+	var game := await _make_table()
+
+	assert_eq(
+		game._title.text, "The Mighty Pyramid of Doom", "a usable word bank rolls a real name"
+	)
+
+
+func test_rerolling_with_an_empty_word_bank_is_safe() -> void:
+	WordBankLoader.adjectives = []
+	WordBankLoader.nouns = []
+	var game := await _make_table()
+
+	game._reroll_packs()
+	await get_tree().process_frame
+
+	assert_eq(game._title.text, Game.FALLBACK_TITLE, "rerolling does not error either")

--- a/test/unit/test_run_name.gd.uid
+++ b/test/unit/test_run_name.gd.uid
@@ -1,0 +1,1 @@
+uid://b2pehhlt5ljcp


### PR DESCRIPTION
Crash path found while writing the table-level tests for #40.

## The bug

`Game._set_title()` picked a run name straight off the word bank's lists:

```gdscript
var adjective = WordBankLoader.adjectives.pick_random()
var noun = WordBankLoader.nouns.pick_random()
```

`WordBankLoader` is deliberately warn-and-continue — a missing, unopenable or malformed `word_bank.json` leaves it with **empty lists** and still emits its signal, exactly as intended. But picking from an empty array errors with `Can't take value from empty array`, once on load and again on every reroll, and the player is left looking at:

> The &lt;null&gt; Pyramid of &lt;null&gt;

So a half-failed mod download or a hand-edited word bank degraded the loaders gracefully and then broke the screen anyway.

## The fix

Fall back to a plain **"The Pyramid"** when either list is empty — if either is missing there is no whole name to roll, and half a name reads worse than none. Broken mod data now costs a flavourful title rather than the screen, matching how the loaders themselves degrade.

## Tests

Five new tests, 145 → 150:

- an empty word bank falls back instead of erroring,
- missing nouns falls back, missing adjectives falls back,
- a populated word bank still rolls a real name ("The Mighty Pyramid of Doom"),
- rerolling with an empty word bank is safe, since reroll re-rolls the title too.

Verified against the bug — restoring the old code fails four of the five and prints `Can't take value from empty array`.

Also drops the word-bank stubbing the #40 table tests needed to work around this; it's no longer required, and leaving it would have left a comment describing a crash that no longer exists.