### PR TITLE
Add a card inspect overlay (#39)

### DIFF
--- a/source/autoloads/run_manager.gd
+++ b/source/autoloads/run_manager.gd
@@ -5,6 +5,9 @@ signal packs_updated
 # Raised when any card grab begins/ends, so the trash zone can show/hide.
 signal card_drag_started
 signal card_drag_ended
+## Raised when a card asks to be looked at up close. Routed through here rather
+## than up the CardGroup -> collection -> table chain, like the drag signals.
+signal card_inspect_requested(card_texture: Texture2D)
 
 var selected_packs: Array[PackData] = []
 var num_games: int = 5
@@ -55,6 +58,12 @@ func begin_card_drag() -> void:
 
 func end_card_drag() -> void:
 	self.card_drag_ended.emit()
+
+
+## Ask the table to show `card_texture` up close. Passing the texture the card is
+## currently showing means a face-down card inspects as its back, with no peeking.
+func request_card_inspect(card_texture: Texture2D) -> void:
+	self.card_inspect_requested.emit(card_texture)
 
 
 func set_trash_zone_rect(rect: Rect2) -> void:

--- a/source/game/card_inspector.gd
+++ b/source/game/card_inspector.gd
@@ -1,0 +1,33 @@
+class_name CardInspector extends PopupContainer
+
+## Shows a single card large and centred so its challenge text can actually be
+## read. Opened by right-clicking a card on the table.
+
+@onready var _card_image: TextureRect = %CardImage
+
+
+func _ready() -> void:
+	super._ready()
+	gui_input.connect(_on_clicked)
+
+
+func show_card(card_texture: Texture2D) -> void:
+	_card_image.texture = card_texture
+	show()
+
+
+## Escape puts the card away again - the overlay exists to be read and
+## dismissed, so it should not need aiming at the close button.
+func _unhandled_input(event: InputEvent) -> void:
+	if not visible:
+		return
+
+	if event.is_action_pressed("Escape"):
+		_close()
+		get_viewport().set_input_as_handled()
+
+
+## Clicking the card itself dismisses it too.
+func _on_clicked(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.pressed:
+		_close()

--- a/source/game/card_inspector.gd.uid
+++ b/source/game/card_inspector.gd.uid
@@ -1,0 +1,1 @@
+uid://d2e5oxkpw2n3t

--- a/source/game/card_inspector.tscn
+++ b/source/game/card_inspector.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=3 format=3 uid="uid://bq7xk2mvn8dc1"]
+
+[ext_resource type="Script" uid="uid://d2e5oxkpw2n3t" path="res://source/game/card_inspector.gd" id="1_ci001"]
+[ext_resource type="Texture2D" uid="uid://lh3dna1fipe" path="res://assets/sprites/ui/icons/close.png" id="2_ci002"]
+
+[node name="CardInspector" type="PanelContainer"]
+offset_right = 48.0
+offset_bottom = 48.0
+script = ExtResource("1_ci001")
+
+[node name="Margin" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 32
+theme_override_constants/margin_top = 32
+theme_override_constants/margin_right = 32
+theme_override_constants/margin_bottom = 32
+mouse_filter = 2
+
+[node name="CardImage" type="TextureRect" parent="Margin"]
+unique_name_in_owner = true
+layout_mode = 2
+mouse_filter = 2
+expand_mode = 1
+stretch_mode = 5
+
+[node name="Close" type="TextureButton" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 0
+texture_normal = ExtResource("2_ci002")

--- a/source/game/challenge_card.gd
+++ b/source/game/challenge_card.gd
@@ -118,6 +118,13 @@ func _physics_process(_delta: float) -> void:
 
 
 func _on_gui_input(event: InputEvent) -> void:
+	# Right-click inspects the card, matching what right-click already means on
+	# the draft screen. Ignored mid-drag so a stray click can't interrupt one.
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT:
+		if event.pressed and not RunManager.popup_open and not _dragging:
+			RunManager.request_card_inspect(texture)
+		return
+
 	# Begin a potential click/drag on left-press. Motion and release are handled
 	# in _input() so we keep receiving events even when the cursor leaves the
 	# card's rect during a fast drag.

--- a/source/game/game.gd
+++ b/source/game/game.gd
@@ -33,6 +33,7 @@ const DICE_TEXTURES = [
 @onready var _quit_dialog: QuitDialog = %QuitDialog
 @onready var _confirm_save_dialog: ConfirmSaveDialog = %ConfirmSaveDialog
 @onready var _save_game_dialog: SaveGameDialog = %SaveGameDialog
+@onready var _card_inspector: CardInspector = %CardInspector
 
 
 func _ready() -> void:
@@ -56,6 +57,8 @@ func _ready() -> void:
 	_quit_dialog.closing.connect(_on_popup_closing)
 	_confirm_save_dialog.closing.connect(_on_save_closed)
 	_quit_dialog.confirm_quit.connect(_on_quit_confirmed)
+	_card_inspector.closing.connect(_on_popup_closing)
+	RunManager.card_inspect_requested.connect(_on_card_inspect_requested)
 	_confirm_save_dialog.save_confirmed.connect(_on_save_confirmed)
 
 	# Scene Setup
@@ -99,6 +102,7 @@ func _setup_card_table() -> void:
 		_quit_dialog,
 		_confirm_save_dialog,
 		_save_game_dialog,
+		_card_inspector,
 	]:
 		popup.z_as_relative = false
 		popup.z_index = 4096
@@ -220,6 +224,15 @@ func _show_coop_rules() -> void:
 	RunManager.popup_open = true
 
 	_coop_rules.show()
+
+
+## Right-clicking a card asks the table to show it up close.
+func _on_card_inspect_requested(card_texture: Texture2D) -> void:
+	if RunManager.popup_open:
+		return
+
+	RunManager.popup_open = true
+	_card_inspector.show_card(card_texture)
 
 
 func _on_popup_closing() -> void:

--- a/source/game/game.tscn
+++ b/source/game/game.tscn
@@ -1,5 +1,6 @@
 [gd_scene format=3 uid="uid://c7besnigoyson"]
 
+[ext_resource type="PackedScene" uid="uid://bq7xk2mvn8dc1" path="res://source/game/card_inspector.tscn" id="99_ci003"]
 [ext_resource type="Script" uid="uid://3qo2fobue4c5" path="res://source/game/game.gd" id="1_e4lxu"]
 [ext_resource type="Texture2D" uid="uid://u52jchngj51e" path="res://assets/sprites/ui/background.png" id="2_bq0n3"]
 [ext_resource type="Texture2D" uid="uid://277dathaiayc" path="res://assets/sprites/ui/buttons/back_button.png" id="3_bq0n3"]
@@ -216,3 +217,8 @@ unique_name_in_owner = true
 visible = false
 z_index = 3
 layout_mode = 0
+
+[node name="CardInspector" parent="." unique_id=1174360001 instance=ExtResource("99_ci003")]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2

--- a/test/unit/test_card_inspector.gd
+++ b/test/unit/test_card_inspector.gd
@@ -1,0 +1,196 @@
+extends GutTest
+
+# Tests the card inspect overlay (#39): right-clicking a card on the table opens
+# it large and centred, and clicking or Escape puts it away. A face-down card
+# inspects as its back, so the overlay is never a way to peek.
+
+const GAME_SCENE: PackedScene = preload("res://source/game/game.tscn")
+const CHALLENGE_CARD: PackedScene = preload("res://source/game/challenge_card.tscn")
+const INSPECTOR: PackedScene = preload("res://source/game/card_inspector.tscn")
+
+
+func _texture(fill: Color = Color.WHITE) -> ImageTexture:
+	var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+	img.fill(fill)
+	return ImageTexture.create_from_image(img)
+
+
+func _make_pack() -> PackData:
+	var pack := PackData.new()
+	pack.title = "Test"
+	pack.folder_path = "user://test_pack_inspect"
+	var backs: Array[ImageTexture] = [_texture(Color.BLACK)]
+	var primaries: Array[ImageTexture] = [_texture(Color.RED), _texture(Color.GREEN)]
+	pack.backs = backs
+	pack.primaries = primaries
+	return pack
+
+
+func after_each() -> void:
+	RunManager.popup_open = false
+
+
+func _make_table() -> Game:
+	RunManager.clear()
+	RunManager.num_games = 1
+	var packs: Array[PackData] = [_make_pack()]
+	RunManager.selected_packs = packs
+
+	var game := GAME_SCENE.instantiate() as Game
+	add_child_autofree(game)
+	await get_tree().process_frame
+	await get_tree().process_frame
+	return game
+
+
+func _right_click() -> InputEventMouseButton:
+	var event := InputEventMouseButton.new()
+	event.button_index = MOUSE_BUTTON_RIGHT
+	event.pressed = true
+	return event
+
+
+func _first_card(game: Game) -> ChallengeCard:
+	for group in game._card_group_collection._card_groups:
+		if group.pack != null and group._table_cards.size() > 0:
+			return group._table_cards[0]
+	return null
+
+
+# --- Requesting ---
+
+
+func test_right_clicking_a_card_asks_for_an_inspect() -> void:
+	var card := CHALLENGE_CARD.instantiate() as ChallengeCard
+	add_child_autofree(card)
+	await get_tree().process_frame
+	card.set_face_up(_texture(Color.RED))
+
+	watch_signals(RunManager)
+	card._on_gui_input(_right_click())
+
+	assert_signal_emitted(RunManager, "card_inspect_requested")
+
+
+func test_right_click_is_ignored_while_a_popup_is_open() -> void:
+	var card := CHALLENGE_CARD.instantiate() as ChallengeCard
+	add_child_autofree(card)
+	await get_tree().process_frame
+	card.set_face_up(_texture(Color.RED))
+	RunManager.popup_open = true
+
+	watch_signals(RunManager)
+	card._on_gui_input(_right_click())
+
+	assert_signal_not_emitted(RunManager, "card_inspect_requested")
+
+
+func test_right_click_is_ignored_mid_drag() -> void:
+	var card := CHALLENGE_CARD.instantiate() as ChallengeCard
+	add_child_autofree(card)
+	await get_tree().process_frame
+	card.set_face_up(_texture(Color.RED))
+	card._dragging = true
+
+	watch_signals(RunManager)
+	card._on_gui_input(_right_click())
+
+	assert_signal_not_emitted(RunManager, "card_inspect_requested")
+
+
+func test_a_face_down_card_inspects_as_its_back() -> void:
+	var card := CHALLENGE_CARD.instantiate() as ChallengeCard
+	add_child_autofree(card)
+	await get_tree().process_frame
+	var back := _texture(Color.BLACK)
+	card.back_texture = back
+	card.set_face_down(_texture(Color.RED))
+
+	var seen: Array = []
+	RunManager.card_inspect_requested.connect(func(tex): seen.append(tex))
+	card._on_gui_input(_right_click())
+
+	assert_eq(seen.size(), 1, "the request went out")
+	assert_eq(seen[0], back, "it carries the back, so the overlay is no way to peek")
+
+
+# --- The overlay ---
+
+
+func test_show_card_displays_that_texture() -> void:
+	var inspector := INSPECTOR.instantiate() as CardInspector
+	add_child_autofree(inspector)
+	await get_tree().process_frame
+	var front := _texture(Color.RED)
+
+	inspector.show_card(front)
+
+	assert_true(inspector.visible, "the overlay is showing")
+	assert_eq(inspector._card_image.texture, front, "showing the card it was handed")
+
+
+func test_clicking_the_overlay_dismisses_it() -> void:
+	var inspector := INSPECTOR.instantiate() as CardInspector
+	add_child_autofree(inspector)
+	await get_tree().process_frame
+	inspector.show_card(_texture(Color.RED))
+
+	var click := InputEventMouseButton.new()
+	click.button_index = MOUSE_BUTTON_LEFT
+	click.pressed = true
+	inspector._on_clicked(click)
+
+	assert_false(inspector.visible, "clicking puts the card away")
+
+
+func test_dismissing_emits_closing() -> void:
+	var inspector := INSPECTOR.instantiate() as CardInspector
+	add_child_autofree(inspector)
+	await get_tree().process_frame
+	inspector.show_card(_texture(Color.RED))
+
+	watch_signals(inspector)
+	var click := InputEventMouseButton.new()
+	click.button_index = MOUSE_BUTTON_LEFT
+	click.pressed = true
+	inspector._on_clicked(click)
+
+	assert_signal_emitted(inspector, "closing")
+
+
+# --- Wired into the table ---
+
+
+func test_table_opens_the_inspector_on_request() -> void:
+	var game := await _make_table()
+	var front := _texture(Color.RED)
+
+	RunManager.request_card_inspect(front)
+	await get_tree().process_frame
+
+	assert_true(game._card_inspector.visible, "the table opened the overlay")
+	assert_eq(game._card_inspector._card_image.texture, front, "with the requested card")
+	assert_true(RunManager.popup_open, "and marked a popup open so cards stop responding")
+
+
+func test_closing_the_inspector_releases_the_popup_flag() -> void:
+	var game := await _make_table()
+	RunManager.request_card_inspect(_texture(Color.RED))
+	await get_tree().process_frame
+
+	game._card_inspector._close()
+	await get_tree().process_frame
+
+	assert_false(game._card_inspector.visible, "overlay hidden")
+	assert_false(RunManager.popup_open, "and the table is interactive again")
+
+
+func test_right_clicking_a_table_card_opens_the_overlay() -> void:
+	var game := await _make_table()
+	var card := _first_card(game)
+	assert_not_null(card, "the table dealt a card to right-click")
+
+	card._on_gui_input(_right_click())
+	await get_tree().process_frame
+
+	assert_true(game._card_inspector.visible, "right-clicking a dealt card opens the overlay")

--- a/test/unit/test_card_inspector.gd.uid
+++ b/test/unit/test_card_inspector.gd.uid
@@ -1,0 +1,1 @@
+uid://1quuvug0qwnu


### PR DESCRIPTION
Closes #39.

Cards on the table are small enough that a challenge can be hard to read, and the existing hover only nudges them to **1.25x** — so "zoom" needed to be something more deliberate than a bigger hover.

## What this adds

**Right-clicking a card** opens it large and centred over the table. Clicking it or pressing **Escape** puts it away.

Right-click already means "secondary action" in this codebase — it favourites a pack on the draft screen — so the gesture is consistent rather than new.

## Two details worth noting

- **A face-down card inspects as its back.** The overlay is handed whatever texture the card is currently showing, so it can't be used to peek at the opening hand before flipping it.
- **The request routes through `RunManager`**, which already coordinates card drag and z-index, rather than threading a signal up through `CardGroup` → collection → table. Same pattern as the existing `card_drag_started`/`card_drag_ended`.

The overlay sits in the popup z-band (4096) with the other dialogs, and sets `popup_open` while it's up so cards stop responding to drags behind it.

## Tests

10 new tests, 150 → 160, all passing:

- Requesting — right-click asks for an inspect, and is ignored both while a popup is open and mid-drag so a stray click can't interrupt a drag.
- Peeking — a face-down card's request carries its **back** texture.
- The overlay — `show_card` displays what it was handed, clicking dismisses it, and dismissing emits `closing`.
- Wired into the table — a request opens the overlay with the right card and marks a popup open, closing releases that flag, and right-clicking an actually-dealt card opens it.