### PR TITLE
Apply mod updates without prompting on boot (#42)

### DIFF
--- a/source/autoloads/user_settings_manager.gd
+++ b/source/autoloads/user_settings_manager.gd
@@ -4,6 +4,7 @@ signal music_volume_updated
 signal sfx_volume_updated
 signal background_set
 signal duplicate_culling_updated
+signal auto_update_mods_updated
 
 const SAVE_PATH = "user://settings.cfg"
 const DB_LOWER_LIMIT: int = 30
@@ -18,6 +19,9 @@ var background: String = "Default"
 ## When on, a draft avoids rolling the same pack twice until every selected pack
 ## has been used once. See RunManager.get_random_loadout().
 var duplicate_culling: bool = true
+## When on, the updater downloads and applies new mod data on boot instead of
+## stopping to ask. See Updater._check_update_data().
+var auto_update_mods: bool = true
 
 # updater
 var latest_version: String = ""
@@ -61,6 +65,12 @@ func update_duplicate_culling(new_value: bool) -> void:
 	self.duplicate_culling_updated.emit()
 
 
+func update_auto_update_mods(new_value: bool) -> void:
+	auto_update_mods = new_value
+	_save_config()
+	self.auto_update_mods_updated.emit()
+
+
 func update_latest_version(new_value: String) -> void:
 	latest_version = new_value
 	_save_config()
@@ -102,6 +112,8 @@ func _load_config() -> void:
 
 		duplicate_culling = config.get_value("settings", "duplicate_culling", true)
 
+		auto_update_mods = config.get_value("settings", "auto_update_mods", true)
+
 	if config.has_section("updater"):
 		latest_version = config.get_value("updater", "latest_version", "")
 
@@ -113,6 +125,7 @@ func _save_config() -> void:
 	config.set_value("settings", "fullscreen", fullscreen)
 	config.set_value("settings", "background", background)
 	config.set_value("settings", "duplicate_culling", duplicate_culling)
+	config.set_value("settings", "auto_update_mods", auto_update_mods)
 
 	# Updater
 	config.set_value("updater", "latest_version", latest_version)

--- a/source/menus/pause_menu.gd
+++ b/source/menus/pause_menu.gd
@@ -7,6 +7,7 @@ class_name PauseMenu extends PopupContainer
 @onready var _background_select: OptionButton = %BackgroundSelect
 @onready var _fullscreen_toggle: CheckBox = %FullscreenToggle
 @onready var _duplicate_culling_toggle: CheckBox = %DuplicateCullingToggle
+@onready var _auto_update_toggle: CheckBox = %AutoUpdateToggle
 @onready var _mods_options: VBoxContainer = %ModsOptions
 @onready var _offical_mods_button: Button = %OfficialMods
 @onready var _local_mods_button: Button = %LocalMods
@@ -23,6 +24,7 @@ func _ready() -> void:
 	_sfx_volume.set_level(floor(UserSettingsManager.sfx_volume * 10))
 	_fullscreen_toggle.button_pressed = UserSettingsManager.fullscreen
 	_duplicate_culling_toggle.button_pressed = UserSettingsManager.duplicate_culling
+	_auto_update_toggle.button_pressed = UserSettingsManager.auto_update_mods
 	_setup_background_options()
 
 	# callbacks
@@ -31,6 +33,7 @@ func _ready() -> void:
 	_background_select.item_selected.connect(_on_background_selected)
 	_fullscreen_toggle.pressed.connect(_fullscreen_toggled)
 	_duplicate_culling_toggle.pressed.connect(_duplicate_culling_toggled)
+	_auto_update_toggle.pressed.connect(_auto_update_toggled)
 	_offical_mods_button.pressed.connect(_open_official_mods)
 	_local_mods_button.pressed.connect(_open_mod_manager)
 
@@ -49,6 +52,10 @@ func _fullscreen_toggled() -> void:
 
 func _duplicate_culling_toggled() -> void:
 	UserSettingsManager.update_duplicate_culling(!UserSettingsManager.duplicate_culling)
+
+
+func _auto_update_toggled() -> void:
+	UserSettingsManager.update_auto_update_mods(!UserSettingsManager.auto_update_mods)
 
 
 func _setup_background_options() -> void:

--- a/source/menus/pause_menu.tscn
+++ b/source/menus/pause_menu.tscn
@@ -69,6 +69,17 @@ layout_mode = 2
 layout_mode = 2
 text = "Avoid duplicate games when drafting"
 
+[node name="AutoUpdateRow" type="HBoxContainer" parent="VBoxContainer/VBoxContainer" unique_id=1174370001]
+layout_mode = 2
+
+[node name="AutoUpdateToggle" type="CheckBox" parent="VBoxContainer/VBoxContainer/AutoUpdateRow" unique_id=1174370002]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer/VBoxContainer/AutoUpdateRow" unique_id=1174370003]
+layout_mode = 2
+text = "Download mod updates automatically"
+
 [node name="ModsOptions" type="VBoxContainer" parent="VBoxContainer/VBoxContainer" unique_id=414733242]
 unique_name_in_owner = true
 visible = false

--- a/source/updater/updater.gd
+++ b/source/updater/updater.gd
@@ -105,6 +105,11 @@ func _check_update_data(
 		_load_data()
 		return
 
+	if _should_download_without_asking():
+		_label.text = "New Updates Found!"
+		_download_updates()
+		return
+
 	if UserSettingsManager.latest_version == "":
 		_label.text = "Mod updates available, download?"
 	else:
@@ -113,6 +118,15 @@ func _check_update_data(
 	_loading_animation.hide()
 	_download_button.show()
 	_skip_button.show()
+
+
+## Whether a found update should just be applied. Boot should not sit waiting on
+## a decision the player almost always makes the same way, and extracting to a
+## temp dir before swapping already means a bad download can't damage existing
+## mods - so downloading unasked is safe. Players who want the say can turn the
+## setting off and get the old prompt back.
+func _should_download_without_asking() -> bool:
+	return UserSettingsManager.auto_update_mods
 
 
 func _download_updates() -> void:

--- a/test/unit/test_auto_update_setting.gd
+++ b/test/unit/test_auto_update_setting.gd
@@ -1,0 +1,108 @@
+extends GutTest
+
+# Tests the automatic mod update setting (#42): boot no longer stops to ask
+# before downloading new mod data, and the prompt is still available to players
+# who turn the setting off.
+
+const PAUSE_MENU: PackedScene = preload("res://source/menus/pause_menu.tscn")
+
+var _saved_auto_update: bool
+
+
+func before_each() -> void:
+	_saved_auto_update = UserSettingsManager.auto_update_mods
+
+
+func after_each() -> void:
+	UserSettingsManager.update_auto_update_mods(_saved_auto_update)
+
+
+# --- The setting ---
+
+
+func test_defaults_to_on() -> void:
+	var config := ConfigFile.new()
+	config.load(UserSettingsManager.SAVE_PATH)
+	assert_true(
+		config.get_value("settings", "auto_update_mods", true),
+		"a settings file without the key reads as automatic updates enabled"
+	)
+
+
+func test_update_emits_signal() -> void:
+	watch_signals(UserSettingsManager)
+	UserSettingsManager.update_auto_update_mods(false)
+	assert_signal_emitted(UserSettingsManager, "auto_update_mods_updated")
+
+
+func test_update_persists_both_ways() -> void:
+	UserSettingsManager.update_auto_update_mods(false)
+	var config := ConfigFile.new()
+	assert_eq(config.load(UserSettingsManager.SAVE_PATH), OK, "settings written")
+	assert_false(config.get_value("settings", "auto_update_mods", true), "off persisted")
+
+	UserSettingsManager.update_auto_update_mods(true)
+	assert_eq(config.load(UserSettingsManager.SAVE_PATH), OK, "settings written again")
+	assert_true(config.get_value("settings", "auto_update_mods", false), "on persisted")
+
+
+# --- The settings popup ---
+
+
+func _build_menu() -> PauseMenu:
+	var menu := PAUSE_MENU.instantiate() as PauseMenu
+	add_child_autofree(menu)
+	await get_tree().process_frame
+	return menu
+
+
+func test_toggle_seeds_from_the_setting() -> void:
+	UserSettingsManager.update_auto_update_mods(false)
+
+	var menu := await _build_menu()
+
+	assert_true(is_instance_valid(menu._auto_update_toggle), "the toggle resolved")
+	assert_false(menu._auto_update_toggle.button_pressed, "seeded from the saved setting")
+
+
+func test_clicking_the_toggle_flips_the_setting() -> void:
+	UserSettingsManager.update_auto_update_mods(true)
+	var menu := await _build_menu()
+
+	menu._auto_update_toggle.pressed.emit()
+	assert_false(UserSettingsManager.auto_update_mods, "click turns automatic updates off")
+
+	menu._auto_update_toggle.pressed.emit()
+	assert_true(UserSettingsManager.auto_update_mods, "clicking again turns them back on")
+
+
+# --- The updater's decision ---
+
+
+func _updater() -> Updater:
+	# Instantiated outside the tree, like the zip-safety tests: this exercises
+	# only the decision, never the boot flow's network request or timers.
+	return Updater.new()
+
+
+func test_updater_downloads_without_asking_when_enabled() -> void:
+	UserSettingsManager.update_auto_update_mods(true)
+	var updater := _updater()
+
+	assert_true(
+		updater._should_download_without_asking(), "an available update is applied unprompted"
+	)
+
+	updater.free()
+
+
+func test_updater_still_prompts_when_disabled() -> void:
+	UserSettingsManager.update_auto_update_mods(false)
+	var updater := _updater()
+
+	assert_false(
+		updater._should_download_without_asking(),
+		"turning the setting off brings the download prompt back"
+	)
+
+	updater.free()

--- a/test/unit/test_auto_update_setting.gd.uid
+++ b/test/unit/test_auto_update_setting.gd.uid
@@ -1,0 +1,1 @@
+uid://cx3uavgdc7j63


### PR DESCRIPTION
Closes #42.

Boot stopped and waited for a Download/Skip decision every time the mods repo had moved on — a decision players almost always make the same way, standing between them and the game.

## What changes

The updater now **downloads and applies new mod data straight away**, with no prompt.

That's safe because of how the flow already works: it extracts the archive to a temporary directory and only swaps it into `user://mods/` once extraction has finished cleanly, rejecting zip-slip entries along the way. A bad or malicious download still can't damage the mods already installed, so downloading unasked doesn't add risk.

Players who want the say back get a **"Download mod updates automatically"** setting in the pause menu. Turning it off restores the old prompt exactly — same buttons, same wording.

## Note on testability

The decision lives in its own `_should_download_without_asking()` method so it can be exercised on an `Updater` instantiated **outside the tree**, the way `_is_safe_zip_entry` already is. The surrounding boot flow can't be unit-tested — it makes a real HTTP request and awaits a 15-second network timer — so pulling the branch out is what makes the behaviour coverable at all rather than resting on review.

## Tests

7 new tests, 160 → 167, all passing:

- The setting defaults to on, emits its signal, and persists both ways.
- The pause menu's toggle resolves, seeds from the saved setting, and flips it when clicked.
- The updater downloads without asking when enabled, and still prompts when disabled.