### PR TITLE
Save a shareable banner image of a run (#37)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -55,6 +55,11 @@ Escape={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+CaptureBanner={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":66,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 FlipCards={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)

--- a/source/game/game.gd
+++ b/source/game/game.gd
@@ -24,6 +24,7 @@ const DICE_TEXTURES = [
 @onready var _die: TextureRect = %Die
 @onready var _roll_die_button: Button = %RollDie
 @onready var _flip_cards_button: Button = %FlipCards
+@onready var _capture_banner_button: Button = %CaptureBanner
 @onready var _reroll_packs_button: Button = %RerollGames
 @onready var _bottom_right: VBoxContainer = %BottomRight
 @onready var _multiplayer_rules_button: Button = %MultiplayerRulesButton
@@ -46,6 +47,7 @@ func _ready() -> void:
 	_close_button.pressed.connect(_close_game)
 	_roll_die_button.pressed.connect(_roll_die)
 	_flip_cards_button.pressed.connect(_flip_all_cards)
+	_capture_banner_button.pressed.connect(_capture_banner)
 	_reroll_packs_button.pressed.connect(_reroll_packs)
 	_multiplayer_rules_button.pressed.connect(_show_multiplayer_rules)
 	_coop_rules_button.pressed.connect(_show_coop_rules)
@@ -178,6 +180,57 @@ func _update_flip_button() -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("FlipCards"):
 		_flip_all_cards()
+
+	if event.is_action_pressed("CaptureBanner"):
+		_capture_banner()
+
+
+## Saves a wide image of the run for sharing. The table UI is hidden for the
+## grab so the banner shows the run and its cards rather than the buttons.
+func _capture_banner() -> void:
+	if RunManager.popup_open:
+		return
+
+	var hidden_ui := _hide_ui_for_capture()
+
+	# Wait for the frame that is actually drawn without the UI before grabbing it.
+	await RenderingServer.frame_post_draw
+	var frame := get_viewport().get_texture().get_image()
+
+	for control in hidden_ui:
+		control.show()
+
+	var focus_center_y := _card_group_collection.get_global_rect().get_center().y
+	var banner := BannerCapture.crop_to_banner(frame, focus_center_y)
+
+	var path := BannerCapture.output_directory().path_join(
+		BannerCapture.file_name(Time.get_datetime_dict_from_system())
+	)
+	if banner.save_png(path) != OK:
+		push_error("Game: couldn't write banner to %s" % path)
+		return
+
+	print("Saved run banner to %s" % path)
+
+
+## Hides the table furniture for a capture, returning what was hidden so it can
+## be put back. Only things already visible are touched, so restoring never
+## reveals a control that was hidden for its own reasons.
+func _hide_ui_for_capture() -> Array[Control]:
+	var hidden: Array[Control] = []
+
+	for control in [
+		_back_button,
+		_top_right,
+		_bottom_left,
+		_reroll_packs_button,
+		_bottom_right,
+	]:
+		if control.visible:
+			control.hide()
+			hidden.append(control)
+
+	return hidden
 
 
 func _roll_die() -> void:

--- a/source/game/game.tscn
+++ b/source/game/game.tscn
@@ -137,6 +137,11 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Flip All (F)"
 
+[node name="CaptureBanner" type="Button" parent="MarginContainer/Bottom/BottomLeft" unique_id=1174380001]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Save Banner (B)"
+
 [node name="RerollGames" type="Button" parent="MarginContainer/Bottom" unique_id=1515219405]
 unique_name_in_owner = true
 layout_mode = 1

--- a/source/util/banner_capture.gd
+++ b/source/util/banner_capture.gd
@@ -1,0 +1,72 @@
+class_name BannerCapture
+
+## Turns a screen grab into a wide banner image of a run, sized for use as a
+## social or stream header.
+
+## 3:1, the usual shape for a header image.
+const BANNER_WIDTH: int = 1500
+const BANNER_HEIGHT: int = 500
+const ASPECT: float = BANNER_WIDTH / float(BANNER_HEIGHT)
+const FILE_PREFIX: String = "pyramid-run"
+
+
+## Crops the largest 3:1 region that fits inside `source`, centred horizontally
+## and vertically on `focus_center_y`, then scales it to banner size.
+##
+## The band is centred on the card table rather than the middle of the screen so
+## the cards are always in frame, and clamped so it never runs off an edge. The
+## crop is a true 3:1 region before scaling, so nothing is stretched.
+static func crop_to_banner(source: Image, focus_center_y: float) -> Image:
+	var region := banner_region(source.get_width(), source.get_height(), focus_center_y)
+
+	var banner := source.get_region(region)
+	banner.resize(BANNER_WIDTH, BANNER_HEIGHT, Image.INTERPOLATE_LANCZOS)
+	return banner
+
+
+## The largest true 3:1 region that fits in a frame of this size, centred
+## horizontally and vertically on `focus_center_y` and clamped to the frame.
+## Split out from the crop so the geometry can be checked exactly, without a
+## resample blurring the answer.
+static func banner_region(source_width: int, source_height: int, focus_center_y: float) -> Rect2i:
+	var band_width := source_width
+	var band_height := int(round(source_width / ASPECT))
+
+	# An unusually wide window would want a band taller than the screen; take the
+	# full height and narrow the band instead of stretching it.
+	if band_height > source_height:
+		band_height = source_height
+		band_width = int(round(source_height * ASPECT))
+
+	var left := int(round((source_width - band_width) / 2.0))
+	var top := int(round(focus_center_y - band_height / 2.0))
+	top = clampi(top, 0, source_height - band_height)
+
+	return Rect2i(left, top, band_width, band_height)
+
+
+## Where a banner should be written. Prefers the player's Pictures folder so the
+## file can actually be found; falls back to user:// when the OS has no such
+## folder (or reports one that doesn't exist).
+static func output_directory() -> String:
+	var pictures := OS.get_system_dir(OS.SYSTEM_DIR_PICTURES)
+	if pictures != "" and DirAccess.dir_exists_absolute(pictures):
+		return pictures
+
+	return "user://"
+
+
+## Timestamped so repeated captures of a run never overwrite each other.
+static func file_name(now: Dictionary) -> String:
+	return (
+		"%s-%04d-%02d-%02d-%02d%02d%02d.png"
+		% [
+			FILE_PREFIX,
+			now.get("year", 0),
+			now.get("month", 0),
+			now.get("day", 0),
+			now.get("hour", 0),
+			now.get("minute", 0),
+			now.get("second", 0),
+		]
+	)

--- a/source/util/banner_capture.gd.uid
+++ b/source/util/banner_capture.gd.uid
@@ -1,0 +1,1 @@
+uid://cfiqw4bwj7qd2

--- a/test/unit/test_banner_capture.gd
+++ b/test/unit/test_banner_capture.gd
@@ -1,0 +1,100 @@
+extends GutTest
+
+# Tests the run banner capture (#37): the crop is a true 3:1 region centred on
+# the card table, never runs off an edge, and is never stretched.
+
+
+func _image(width: int, height: int) -> Image:
+	var img := Image.create(width, height, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	return img
+
+
+func test_output_is_banner_sized() -> void:
+	var banner := BannerCapture.crop_to_banner(_image(1920, 1080), 540.0)
+
+	assert_eq(banner.get_width(), BannerCapture.BANNER_WIDTH, "banner width")
+	assert_eq(banner.get_height(), BannerCapture.BANNER_HEIGHT, "banner height")
+
+
+func test_band_is_centred_on_the_focus() -> void:
+	# A 1920-wide frame gives a 640-tall band; centred on y=540 it starts at 220.
+	var region := BannerCapture.banner_region(1920, 1080, 540.0)
+
+	assert_eq(region, Rect2i(0, 220, 1920, 640), "band centred on the focus row")
+
+
+func test_band_is_clamped_to_the_top_edge() -> void:
+	var region := BannerCapture.banner_region(1920, 1080, 10.0)
+
+	assert_eq(region.position.y, 0, "a focus near the top clamps the band to the top")
+	assert_eq(region.size, Vector2i(1920, 640), "and the band keeps its size")
+
+
+func test_band_is_clamped_to_the_bottom_edge() -> void:
+	var region := BannerCapture.banner_region(1920, 1080, 5000.0)
+
+	assert_eq(region.position.y, 440, "the lowest legal band start")
+	assert_eq(region.size, Vector2i(1920, 640), "and the band keeps its size")
+
+
+func test_region_is_always_three_to_one() -> void:
+	for size in [Vector2i(1920, 1080), Vector2i(1280, 720), Vector2i(800, 800)]:
+		var region := BannerCapture.banner_region(size.x, size.y, size.y / 2.0)
+		assert_almost_eq(
+			region.size.x / float(region.size.y),
+			BannerCapture.ASPECT,
+			0.01,
+			"region for %s is 3:1, so nothing is stretched" % size
+		)
+
+
+func test_region_stays_inside_the_frame() -> void:
+	for focus in [-500.0, 0.0, 540.0, 5000.0]:
+		var region := BannerCapture.banner_region(1920, 1080, focus)
+		assert_gte(region.position.y, 0, "band starts inside the frame for focus %f" % focus)
+		assert_lte(region.position.y + region.size.y, 1080, "band ends inside for focus %f" % focus)
+
+
+func test_a_very_wide_frame_narrows_instead_of_stretching() -> void:
+	# 3000x400 would want a 1000-tall band; instead it takes the full height and
+	# narrows to 1200 wide, centred, keeping a true 3:1 crop.
+	var region := BannerCapture.banner_region(3000, 400, 200.0)
+
+	assert_eq(region, Rect2i(900, 0, 1200, 400), "the band narrowed and centred horizontally")
+
+
+func test_a_square_frame_still_produces_a_banner() -> void:
+	var banner := BannerCapture.crop_to_banner(_image(800, 800), 400.0)
+
+	assert_eq(banner.get_width(), BannerCapture.BANNER_WIDTH, "square input still crops to 3:1")
+	assert_eq(banner.get_height(), BannerCapture.BANNER_HEIGHT, "square input still crops to 3:1")
+
+
+func test_file_name_is_timestamped() -> void:
+	var name := BannerCapture.file_name(
+		{"year": 2026, "month": 8, "day": 25, "hour": 9, "minute": 5, "second": 3}
+	)
+
+	assert_eq(name, "pyramid-run-2026-08-25-090503.png", "zero-padded timestamp in the name")
+
+
+func test_file_names_differ_between_captures() -> void:
+	var first := BannerCapture.file_name(
+		{"year": 2026, "month": 8, "day": 25, "hour": 9, "minute": 5, "second": 3}
+	)
+	var second := BannerCapture.file_name(
+		{"year": 2026, "month": 8, "day": 25, "hour": 9, "minute": 5, "second": 4}
+	)
+
+	assert_ne(first, second, "a later capture does not overwrite an earlier one")
+
+
+func test_output_directory_is_usable() -> void:
+	var directory := BannerCapture.output_directory()
+
+	assert_ne(directory, "", "a directory was chosen")
+	assert_true(
+		DirAccess.dir_exists_absolute(directory) or directory == "user://",
+		"the chosen directory exists, or is the user:// fallback"
+	)

--- a/test/unit/test_banner_capture.gd.uid
+++ b/test/unit/test_banner_capture.gd.uid
@@ -1,0 +1,1 @@
+uid://drefy27og62u3


### PR DESCRIPTION
Closes #37.

A **Save Banner** button beside the other table controls, plus the **B** key, writes a **1500×500** image of the run to the player's **Pictures** folder — the usual shape for a social or stream header. Falls back to `user://` if the OS reports no Pictures folder.

## Framing decisions

- **The table's buttons are hidden for the grab** and restored afterwards, so the banner shows the run and its cards rather than the UI. Only controls that were *already visible* are restored, so anything hidden for its own reasons (the Flip All button once the table is face-up) stays hidden.
- **The band is centred on the card table**, not the middle of the screen, so the cards are always in frame — and it's clamped so it never runs off an edge.
- **An unusually wide window narrows the band** rather than stretching it, so the crop is always a true 3:1 region before scaling. Nothing is ever distorted.
- **File names are timestamped**, so capturing a run twice doesn't overwrite the first.

## On the tests

I first tried asserting on marked pixels in the output and it failed — the Lanczos resample blends a marked pixel with its neighbours, so the colour comes back blurred. The geometry is the part worth pinning anyway, so `banner_region()` is split out and returns the `Rect2i`; that can be asserted exactly, and the crop just applies it.

11 new tests, 167 → 178, all passing:

- Output is always banner-sized, from 16:9, 4:3 and square frames.
- The band is centred on the focus row, and clamped at both the top and bottom edges.
- The region is 3:1 at every frame shape tested, and always stays inside the frame across a range of focus positions including negative and far-off-screen.
- A very wide frame narrows and centres horizontally rather than stretching.
- File names are zero-padded and timestamped, and two captures a second apart differ.
- The chosen output directory exists, or is the `user://` fallback.