### PR TITLE
Move curses from the primary pile to the secondary pile (#43)

### DIFF
--- a/source/game/card_deck.gd
+++ b/source/game/card_deck.gd
@@ -6,10 +6,14 @@ class_name CardDeck extends RefCounted
 ##   curse card   -> -(index in pack.curses) - 1            (entry <  0)
 ## Secondary piles only ever hold primary-style (>= 0) entries.
 ##
-## Core invariant for primary piles: the next drawable card (the top) is always
-## a primary. Drawing a primary reveals at most one curse (which the caller flies
-## to the curse slot); any further consecutive curses are recycled to the bottom
-## so two curses never surface back-to-back.
+## Core invariant for either pile: the next drawable card (the top) is never a
+## curse. Drawing reveals at most one curse (which the caller flies to the curse
+## slot); any further consecutive curses are recycled to the bottom so two curses
+## never surface back-to-back.
+##
+## Curses normally ride the secondary pile. A pack with no secondaries has no
+## secondary pile for them to live in, so there they ride the primary pile
+## instead - either way only one pile carries them.
 
 ## Guards the recycle loop against a pile that somehow contains no primary.
 const _RECYCLE_SAFETY: int = 4096
@@ -42,7 +46,8 @@ func is_empty() -> bool:
 	return cards.is_empty()
 
 
-func has_primary() -> bool:
+## Whether anything in the pile can still be drawn as a normal card.
+func has_non_curse() -> bool:
 	for entry in cards:
 		if not is_curse(entry):
 			return true
@@ -54,53 +59,83 @@ func peek() -> int:
 	return cards[0]
 
 
-func build_primary(num_primaries: int, num_curses: int) -> void:
+## Curses only belong here when the pack has no secondary pile to carry them.
+func build_primary(num_primaries: int, num_curses: int = 0) -> void:
+	_build(num_primaries, num_curses)
+
+
+## The usual home for curses.
+func build_secondary(num_secondaries: int, num_curses: int = 0) -> void:
+	_build(num_secondaries, num_curses)
+
+
+func _build(num_cards: int, num_curses: int) -> void:
 	cards = []
-	for i in range(num_primaries):
+	for i in range(num_cards):
 		cards.append(encode_primary(i))
 	for c in range(num_curses):
 		cards.append(encode_curse(c))
 	cards.shuffle()
-	_ensure_top_primary()
-
-
-func build_secondary(num_secondaries: int) -> void:
-	cards = []
-	for i in range(num_secondaries):
-		cards.append(encode_primary(i))
-	cards.shuffle()
+	_ensure_top_non_curse()
 
 
 ## Draw the top primary. Returns:
-##   { "primary": <entry> }                 when no curse is revealed
+##   { "primary": <entry> }                   when no curse is revealed
 ##   { "primary": <entry>, "curse": <entry> } when the card under it is a curse
-##   {}                                       when no primary can be drawn
-## After this call the top is guaranteed to be a primary again (or the pile is
-## out of primaries).
+##   {}                                       when nothing can be drawn
+## After this call the top is guaranteed not to be a curse (or the pile is out
+## of ordinary cards).
 func draw_primary() -> Dictionary:
-	_ensure_top_primary()
+	return _draw_revealing_curse("primary")
+
+
+## Draw the top of a secondary pile, with the same shape as draw_primary(): this
+## is where curses normally surface.
+func draw_secondary() -> Dictionary:
+	return _draw_revealing_curse("secondary")
+
+
+func _draw_revealing_curse(key: String) -> Dictionary:
+	_ensure_top_non_curse()
 	if is_empty() or is_curse(cards[0]):
 		return {}
 
-	var primary: int = cards.pop_front()
-	var result := {"primary": primary}
+	var drawn: int = cards.pop_front()
+	var result := {key: drawn}
 
 	# The card now exposed: if it's a curse, it flies to the curse slot. Recycle
 	# any further consecutive curses so they don't surface stacked.
 	if not is_empty() and is_curse(cards[0]):
-		var curse: int = cards.pop_front()
-		result["curse"] = curse
-		_ensure_top_primary()
+		result["curse"] = cards.pop_front()
+		_ensure_top_non_curse()
 
 	return result
 
 
-## Draw the top of a secondary pile. Returns the entry, or -1 if empty.
-func draw_secondary() -> int:
-	if is_empty():
-		return -1
-	var entry: int = cards.pop_front()
-	return entry
+## Removes every curse from this pile and hands them back, for moving them to
+## the pile that should be carrying them.
+func extract_curses() -> Array[int]:
+	var curses: Array[int] = []
+	var kept: Array[int] = []
+
+	for entry in cards:
+		if is_curse(entry):
+			curses.append(entry)
+		else:
+			kept.append(entry)
+
+	cards = kept
+	return curses
+
+
+## Shuffles extra entries into this pile, keeping the top-is-never-a-curse rule.
+func add_shuffled(entries: Array[int]) -> void:
+	if entries.is_empty():
+		return
+
+	cards.append_array(entries)
+	cards.shuffle()
+	_ensure_top_non_curse()
 
 
 ## Send a trashed card (encoded entry) to the bottom of the pile.
@@ -116,10 +151,10 @@ func from_array(state: Array[int]) -> void:
 	cards = state.duplicate()
 
 
-## Rotate leading curses to the bottom until the top is a primary. No-op if the
-## pile has no primaries (so an all-curse remainder doesn't loop forever).
-func _ensure_top_primary() -> void:
-	if not has_primary():
+## Rotate leading curses to the bottom until the top is an ordinary card. No-op
+## if the pile has none left (so an all-curse remainder doesn't loop forever).
+func _ensure_top_non_curse() -> void:
+	if not has_non_curse():
 		return
 
 	var guard := 0

--- a/source/game/card_group.gd
+++ b/source/game/card_group.gd
@@ -49,9 +49,17 @@ func _clear_table() -> void:
 func _setup_new() -> void:
 	_clear_table()
 	_primary_deck = CardDeck.new()
-	_primary_deck.build_primary(pack.primaries.size(), pack.curses.size())
 	_secondary_deck = CardDeck.new()
-	_secondary_deck.build_secondary(pack.secondaries.size())
+
+	if _curses_ride_secondary():
+		_primary_deck.build_primary(pack.primaries.size())
+		_secondary_deck.build_secondary(pack.secondaries.size(), pack.curses.size())
+	else:
+		# No secondary pile for curses to live in, so they stay with the
+		# primaries; otherwise a pack with curses and no secondaries would
+		# quietly lose them.
+		_primary_deck.build_primary(pack.primaries.size(), pack.curses.size())
+		_secondary_deck.build_secondary(pack.secondaries.size())
 
 	_build_piles()
 	_deal_initial()
@@ -66,6 +74,12 @@ func _deal_initial() -> void:
 		_draw_secondary_card(false, false, true)
 	else:
 		_secondary_pile.hide()
+
+
+## Curses belong to the secondary pile, unless the pack has no secondaries for
+## that pile to hold.
+func _curses_ride_secondary() -> bool:
+	return pack != null and pack.secondaries.size() > 0
 
 
 func _build_piles() -> void:
@@ -118,33 +132,38 @@ func _draw_primary_card(flip: bool, start_dragging: bool, face_down: bool = fals
 
 	if result.has("curse"):
 		var curse_entry: int = result["curse"]
-		_reveal_curse(curse_entry, face_down)
+		_reveal_curse(curse_entry, face_down, false)
 
 	_primary_pile.set_remaining(_primary_deck.size())
 
 
 func _draw_secondary_card(flip: bool, start_dragging: bool, face_down: bool = false) -> void:
-	var entry := _secondary_deck.draw_secondary()
-	if entry == -1:
+	var result := _secondary_deck.draw_secondary()
+	if result.is_empty():
 		_secondary_pile.set_remaining(0)
 		return
 
+	var entry: int = result["secondary"]
 	var card := _spawn_card(entry, true, false, _slot_position(true), flip, face_down)
 	if start_dragging:
 		card.begin_drag_from_pile()
 
+	if result.has("curse"):
+		var curse_entry: int = result["curse"]
+		_reveal_curse(curse_entry, face_down, true)
+
 	_secondary_pile.set_remaining(_secondary_deck.size())
 
 
-func _reveal_curse(curse_entry: int, face_down: bool = false) -> void:
+func _reveal_curse(curse_entry: int, face_down: bool = false, from_secondary: bool = false) -> void:
 	# Only one curse is shown at a time; retire the previous one.
 	if _curse_card != null and is_instance_valid(_curse_card):
 		_table_cards.erase(_curse_card)
 		_curse_card.queue_free()
 
-	# Fly the curse from the primary pile to the curse slot.
+	# Fly the curse out of whichever pile actually surfaced it.
 	var card := _spawn_card(
-		curse_entry, false, true, _slot_position(false), not face_down, face_down
+		curse_entry, false, true, _slot_position(from_secondary), not face_down, face_down
 	)
 	_curse_card = card
 
@@ -291,6 +310,8 @@ func load_from_card_group_data(data: CardGroupData) -> void:
 	_secondary_deck = CardDeck.new()
 	_secondary_deck.from_array(data.secondary_deck)
 
+	_migrate_curses_from_save()
+
 	_build_piles()
 	for saved in data.table_cards:
 		_restore_card(saved)
@@ -301,6 +322,16 @@ func load_from_card_group_data(data: CardGroupData) -> void:
 		_secondary_pile.hide()
 
 	_loading_from_save = false
+
+
+## Saves written before curses moved to the secondary pile have them encoded in
+## the primary deck, where the draw path no longer looks for them - and where a
+## curse index would be read as a primary index. Move them across on load.
+func _migrate_curses_from_save() -> void:
+	if not _curses_ride_secondary():
+		return
+
+	_secondary_deck.add_shuffled(_primary_deck.extract_curses())
 
 
 func _restore_card(saved: Dictionary) -> void:

--- a/test/unit/test_curses_on_secondary.gd
+++ b/test/unit/test_curses_on_secondary.gd
@@ -1,0 +1,254 @@
+extends GutTest
+
+# Tests curses moving to the secondary pile (#43): primary draws come up clean,
+# curses surface from the secondary pile, packs with no secondaries keep their
+# curses on the primary pile, and saves from before the move are migrated.
+
+const PACK_DIR: String = "user://test_pack_curses"
+const CARD_GROUP_SCENE: PackedScene = preload("res://source/game/card_group.tscn")
+
+
+func _texture() -> ImageTexture:
+	var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	return ImageTexture.create_from_image(img)
+
+
+func _textures(count: int) -> Array[ImageTexture]:
+	var out: Array[ImageTexture] = []
+	for i in range(count):
+		out.append(_texture())
+	return out
+
+
+func _pack(primaries: int, secondaries: int, curses: int) -> PackData:
+	var pack := PackData.new()
+	pack.title = "Test"
+	pack.folder_path = "user://test_pack_curses"
+	var backs: Array[ImageTexture] = [_texture()]
+	pack.backs = backs
+	pack.primaries = _textures(primaries)
+	pack.secondaries = _textures(secondaries)
+	pack.curses = _textures(curses)
+	return pack
+
+
+func _group(pack: PackData) -> CardGroup:
+	RunManager.num_games = 1
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+	group.pack = pack
+	await get_tree().process_frame
+	return group
+
+
+func _count_curses(deck: CardDeck) -> int:
+	var total := 0
+	for entry in deck.to_array():
+		if CardDeck.is_curse(entry):
+			total += 1
+	return total
+
+
+## Curses still in the pile plus any already dealt onto the table. The opening
+## deal can pull a curse out of a pile, so counting the pile alone would depend
+## on shuffle luck.
+func _curses_accounted_for(group: CardGroup, deck: CardDeck) -> int:
+	var total := _count_curses(deck)
+	for card in group._table_cards:
+		if is_instance_valid(card) and card.is_curse:
+			total += 1
+	return total
+
+
+# --- Where curses live ---
+
+
+func test_curses_go_to_the_secondary_pile() -> void:
+	var group := await _group(_pack(4, 3, 2))
+
+	assert_eq(_count_curses(group._primary_deck), 0, "the primary pile is clean")
+	assert_eq(
+		_curses_accounted_for(group, group._secondary_deck),
+		2,
+		"both curses ride the secondary pile"
+	)
+
+
+func test_a_pack_without_secondaries_keeps_curses_on_the_primary_pile() -> void:
+	# Four real packs ship curses and no secondaries; they must not lose them.
+	var group := await _group(_pack(4, 0, 2))
+
+	assert_eq(
+		_curses_accounted_for(group, group._primary_deck),
+		2,
+		"with no secondary pile to ride, curses stay with the primaries"
+	)
+
+
+func test_a_pack_with_no_curses_is_unaffected() -> void:
+	var group := await _group(_pack(4, 3, 0))
+
+	assert_eq(_curses_accounted_for(group, group._primary_deck), 0, "no curses anywhere")
+	assert_eq(_curses_accounted_for(group, group._secondary_deck), 0, "no curses anywhere")
+
+
+# --- Drawing ---
+
+
+func test_drawing_a_primary_never_surfaces_a_curse() -> void:
+	var group := await _group(_pack(4, 3, 2))
+
+	for _draw in range(4):
+		var result := group._primary_deck.draw_primary()
+		if result.is_empty():
+			break
+		assert_false(result.has("curse"), "a primary draw is clean")
+
+
+func test_drawing_a_secondary_can_surface_a_curse() -> void:
+	var group := await _group(_pack(4, 3, 2))
+
+	# Stack the pile so the card under the top is a curse.
+	group._secondary_deck.cards = [
+		CardDeck.encode_primary(0), CardDeck.encode_curse(0), CardDeck.encode_primary(1)
+	]
+
+	var result := group._secondary_deck.draw_secondary()
+
+	assert_true(result.has("secondary"), "a secondary came off the pile")
+	assert_true(result.has("curse"), "and the curse under it surfaced")
+
+
+func test_secondary_draw_leaves_a_drawable_card_on_top() -> void:
+	var deck := CardDeck.new()
+	deck.cards = [
+		CardDeck.encode_primary(0),
+		CardDeck.encode_curse(0),
+		CardDeck.encode_curse(1),
+		CardDeck.encode_primary(1),
+	]
+
+	deck.draw_secondary()
+
+	assert_false(CardDeck.is_curse(deck.peek()), "two curses never surface back to back")
+
+
+func test_drawing_a_secondary_card_puts_a_curse_on_the_table() -> void:
+	var group := await _group(_pack(4, 3, 2))
+	group._secondary_deck.cards = [
+		CardDeck.encode_primary(0), CardDeck.encode_curse(0), CardDeck.encode_primary(1)
+	]
+
+	group._draw_secondary_card(false, false)
+	await get_tree().process_frame
+
+	assert_not_null(group._curse_card, "the curse flew to the curse slot")
+
+
+# --- Deck helpers ---
+
+
+func test_extract_curses_takes_only_curses() -> void:
+	var deck := CardDeck.new()
+	deck.cards = [
+		CardDeck.encode_primary(0),
+		CardDeck.encode_curse(0),
+		CardDeck.encode_primary(1),
+		CardDeck.encode_curse(1),
+	]
+
+	var curses := deck.extract_curses()
+
+	assert_eq(curses.size(), 2, "both curses came out")
+	assert_eq(deck.size(), 2, "the ordinary cards stayed")
+	assert_eq(_count_curses(deck), 0, "and no curse was left behind")
+
+
+func test_add_shuffled_keeps_a_drawable_card_on_top() -> void:
+	var deck := CardDeck.new()
+	deck.cards = [CardDeck.encode_primary(0), CardDeck.encode_primary(1)]
+
+	deck.add_shuffled([CardDeck.encode_curse(0), CardDeck.encode_curse(1)] as Array[int])
+
+	assert_eq(deck.size(), 4, "everything was added")
+	assert_false(CardDeck.is_curse(deck.peek()), "the top is still drawable")
+
+
+func test_add_shuffled_with_nothing_is_a_no_op() -> void:
+	var deck := CardDeck.new()
+	deck.cards = [CardDeck.encode_primary(0)]
+
+	deck.add_shuffled([] as Array[int])
+
+	assert_eq(deck.size(), 1, "nothing changed")
+
+
+# --- Migrating older saves ---
+
+
+func _write_pack_to_disk(secondaries: Array) -> void:
+	DirAccess.make_dir_recursive_absolute(PACK_DIR)
+	var stems := ["b1", "p1", "p2", "p3", "c1"]
+	stems.append_array(secondaries)
+	for stem in stems:
+		var img := Image.create(4, 4, false, Image.FORMAT_RGBA8)
+		img.fill(Color.WHITE)
+		img.save_png("%s/%s.png" % [PACK_DIR, stem])
+
+
+func _remove_pack_from_disk() -> void:
+	var dir := DirAccess.open(PACK_DIR)
+	if dir == null:
+		return
+	for file_name in dir.get_files():
+		dir.remove(file_name)
+	DirAccess.remove_absolute(PACK_DIR)
+
+
+func _legacy_save() -> CardGroupData:
+	# How a save looked when curses rode the primary deck.
+	var data := CardGroupData.new()
+	data.pack_path = PACK_DIR
+	data.primary_deck = [
+		CardDeck.encode_primary(0), CardDeck.encode_curse(0), CardDeck.encode_primary(1)
+	]
+	data.secondary_deck = [CardDeck.encode_primary(0)]
+	data.table_cards = [{"entry": CardDeck.encode_primary(2), "secondary": false, "curse": false}]
+	return data
+
+
+func test_a_legacy_save_moves_its_curses_to_the_secondary_pile() -> void:
+	_write_pack_to_disk(["s1", "s2"])
+	RunManager.num_games = 1
+
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+	group.load_from_card_group_data(_legacy_save())
+	await get_tree().process_frame
+
+	assert_eq(_count_curses(group._primary_deck), 0, "the curse left the primary pile")
+	assert_eq(_count_curses(group._secondary_deck), 1, "and joined the secondary pile")
+
+	_remove_pack_from_disk()
+
+
+func test_a_legacy_save_for_a_pack_without_secondaries_is_left_alone() -> void:
+	_write_pack_to_disk([])
+	RunManager.num_games = 1
+
+	var group := CARD_GROUP_SCENE.instantiate() as CardGroup
+	add_child_autofree(group)
+	await get_tree().process_frame
+	group.load_from_card_group_data(_legacy_save())
+	await get_tree().process_frame
+
+	assert_eq(
+		_count_curses(group._primary_deck),
+		1,
+		"with nowhere to move it, the curse stays on the primary pile"
+	)
+
+	_remove_pack_from_disk()

--- a/test/unit/test_curses_on_secondary.gd.uid
+++ b/test/unit/test_curses_on_secondary.gd.uid
@@ -1,0 +1,1 @@
+uid://coptb5brpxcx7


### PR DESCRIPTION
Closes #43.

Curses now ride the **secondary pile** and surface when a secondary is drawn, so **drawing a primary is always clean**. The curse flies out of whichever pile actually surfaced it, rather than always from the primary slot.

## The case the issue didn't cover

**Four packs in the official mods ship curses but no secondaries** — `downwell`, `isle of arrows`, and both question decks. They have no secondary pile for curses to live in, and the secondary pile is hidden entirely for such packs, so moving curses there unconditionally would have **silently deleted their curses**.

So for a pack with no secondaries, curses stay with the primaries. Either way exactly one pile carries them, and no pack loses content. Happy to change this if you'd rather those four packs simply lose their curses, or get a visible curse-only pile.

## Saves

Saves written before this have curses encoded in the **primary** deck — where the draw path no longer looks for them, and where a curse index would be misread as an index into `pack.primaries`. They're migrated across on load, and a legacy save for a pack with no secondaries is left alone.

## Structure

The top-is-never-a-curse rule and the recycling of consecutive curses now apply to whichever pile carries them, so the draw and rotate logic is shared instead of duplicated. `has_primary` and `_ensure_top_primary` are renamed to `has_non_curse` / `_ensure_top_non_curse` to say what they now mean for both piles.

## Tests

12 new tests, 178 → 190, all passing:

- Curses go to the secondary pile; a pack without secondaries keeps them on the primary pile; a pack with no curses is unaffected.
- Primary draws never surface a curse; secondary draws can; two curses never surface back to back; a secondary draw puts a curse on the table.
- `extract_curses` takes only curses, `add_shuffled` keeps a drawable card on top and no-ops on nothing.
- A legacy save moves its curses across, and a legacy save for a pack without secondaries is left alone.

Both mutations are caught: skipping the migration and dropping the no-secondaries fallback each fail the suite.

One note on process — my first version of these tests counted curses in the pile only, which passed alone but failed in the full suite: the opening deal can pull a curse out of a pile, so the count depended on shuffle luck. They now count pile plus table, and I ran the full suite three times to confirm it's stable.