### PR TITLE
Give buttons hover and press feedback (#16)

### DIFF
--- a/assets/themes/main_theme.tres
+++ b/assets/themes/main_theme.tres
@@ -20,21 +20,94 @@ texture_margin_right = 1.0
 texture_margin_bottom = 4.0
 region_rect = Rect2(0, 0, 2088.2502, 2991.5942)
 
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_card_hover"]
+content_margin_left = 48.0
+content_margin_top = 16.0
+content_margin_right = 48.0
+content_margin_bottom = 16.0
+texture = ExtResource("8_card")
+texture_margin_left = 1.0
+texture_margin_top = 4.0
+texture_margin_right = 1.0
+texture_margin_bottom = 4.0
+region_rect = Rect2(0, 0, 2088.2502, 2991.5942)
+modulate_color = Color(1.25, 1.25, 1.25, 1)
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_card_pressed"]
+content_margin_left = 48.0
+content_margin_top = 16.0
+content_margin_right = 48.0
+content_margin_bottom = 16.0
+texture = ExtResource("8_card")
+texture_margin_left = 1.0
+texture_margin_top = 4.0
+texture_margin_right = 1.0
+texture_margin_bottom = 4.0
+region_rect = Rect2(0, 0, 2088.2502, 2991.5942)
+modulate_color = Color(0.68, 0.68, 0.68, 1)
+
+[sub_resource type="StyleBoxTexture" id="StyleBoxTexture_card_disabled"]
+content_margin_left = 48.0
+content_margin_top = 16.0
+content_margin_right = 48.0
+content_margin_bottom = 16.0
+texture = ExtResource("8_card")
+texture_margin_left = 1.0
+texture_margin_top = 4.0
+texture_margin_right = 1.0
+texture_margin_bottom = 4.0
+region_rect = Rect2(0, 0, 2088.2502, 2991.5942)
+modulate_color = Color(0.55, 0.55, 0.55, 0.55)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_focus_ring"]
+draw_center = false
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.30980393, 0.7294118, 0.8745098, 1)
+expand_margin_left = 6.0
+expand_margin_top = 6.0
+expand_margin_right = 6.0
+expand_margin_bottom = 6.0
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_selectable_hover"]
+content_margin_left = 48.0
+content_margin_top = 16.0
+content_margin_right = 48.0
+content_margin_bottom = 16.0
+bg_color = Color(0.28235295, 0.28235295, 0.28235295, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(1, 1, 1, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_checkbox_hover"]
+bg_color = Color(0.68235296, 0.89803922, 0.96862745, 1)
+border_width_left = 8
+border_width_top = 8
+border_width_right = 8
+border_width_bottom = 8
+border_color = Color(0.30980393, 0.7294118, 0.8745098, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_checkbox_pressed"]
+bg_color = Color(0.41960785, 0.69803923, 0.79607844, 1)
+border_width_left = 8
+border_width_top = 8
+border_width_right = 8
+border_width_bottom = 8
+border_color = Color(0.21960784, 0.52156863, 0.62352943, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_option_hover"]
+bg_color = Color(0.41960785, 0.81960785, 0.9411765, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_option_pressed"]
+bg_color = Color(0.21960784, 0.54901963, 0.68235296, 1)
+
 [sub_resource type="ImageTexture" id="ImageTexture_4fp8c"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0f6i3"]
-bg_color = Color(0.30980393, 0.7294118, 0.8745098, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y0ixg"]
-bg_color = Color(0.30980393, 0.7294118, 0.8745098, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_etupa"]
-bg_color = Color(0.30980393, 0.7294118, 0.8745098, 1)
-
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_luy55"]
-bg_color = Color(0.30980393, 0.7294118, 0.8745098, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_n0pxi"]
 bg_color = Color(0.30980393, 0.7294118, 0.8745098, 1)
 
 [sub_resource type="ImageTexture" id="ImageTexture_0f6i3"]
@@ -50,19 +123,19 @@ BigTitle/font_sizes/font_size = 48
 Button/colors/font_outline_color = Color(0, 0, 0, 1)
 Button/constants/outline_size = 12
 Button/font_sizes/font_size = 32
-Button/styles/disabled = SubResource("StyleBoxTexture_card")
-Button/styles/focus = SubResource("StyleBoxTexture_card")
-Button/styles/hover = SubResource("StyleBoxTexture_card")
+Button/styles/disabled = SubResource("StyleBoxTexture_card_disabled")
+Button/styles/focus = SubResource("StyleBoxFlat_focus_ring")
+Button/styles/hover = SubResource("StyleBoxTexture_card_hover")
 Button/styles/normal = SubResource("StyleBoxTexture_card")
-Button/styles/pressed = SubResource("StyleBoxTexture_card")
+Button/styles/pressed = SubResource("StyleBoxTexture_card_pressed")
 CheckBox/icons/checked = ExtResource("1_gvtt4")
 CheckBox/icons/unchecked = SubResource("ImageTexture_4fp8c")
 CheckBox/styles/disabled = ExtResource("2_axncs")
-CheckBox/styles/focus = ExtResource("2_axncs")
-CheckBox/styles/hover = ExtResource("2_axncs")
-CheckBox/styles/hover_pressed = ExtResource("2_axncs")
+CheckBox/styles/focus = SubResource("StyleBoxFlat_focus_ring")
+CheckBox/styles/hover = SubResource("StyleBoxFlat_checkbox_hover")
+CheckBox/styles/hover_pressed = SubResource("StyleBoxFlat_checkbox_pressed")
 CheckBox/styles/normal = ExtResource("2_axncs")
-CheckBox/styles/pressed = ExtResource("2_axncs")
+CheckBox/styles/pressed = SubResource("StyleBoxFlat_checkbox_pressed")
 ExtraLargeTitle/base_type = &"Label"
 ExtraLargeTitle/colors/font_shadow_color = Color(0, 0, 0, 1)
 ExtraLargeTitle/constants/line_spacing = -24
@@ -91,11 +164,11 @@ OptionButton/constants/h_separation = 16
 OptionButton/constants/outline_size = 8
 OptionButton/font_sizes/font_size = 32
 OptionButton/icons/arrow = ExtResource("5_4fp8c")
-OptionButton/styles/focus = SubResource("StyleBoxFlat_0f6i3")
-OptionButton/styles/hover = SubResource("StyleBoxFlat_y0ixg")
-OptionButton/styles/hover_mirrored = SubResource("StyleBoxFlat_etupa")
+OptionButton/styles/focus = SubResource("StyleBoxFlat_focus_ring")
+OptionButton/styles/hover = SubResource("StyleBoxFlat_option_hover")
+OptionButton/styles/hover_mirrored = SubResource("StyleBoxFlat_option_hover")
 OptionButton/styles/normal = SubResource("StyleBoxFlat_luy55")
-OptionButton/styles/pressed = SubResource("StyleBoxFlat_n0pxi")
+OptionButton/styles/pressed = SubResource("StyleBoxFlat_option_pressed")
 PanelContainer/styles/panel = ExtResource("2_lxams")
 PopupMenu/font_sizes/font_size = 40
 PopupMenu/icons/radio_checked = ExtResource("1_gvtt4")
@@ -103,6 +176,7 @@ PopupMenu/icons/radio_unchecked = SubResource("ImageTexture_0f6i3")
 RichTextLabel/constants/outline_size = 8
 RichTextLabel/font_sizes/normal_font_size = 32
 SelectableButton/base_type = &"Button"
+SelectableButton/styles/hover = SubResource("StyleBoxFlat_selectable_hover")
 SelectableButton/styles/focus = ExtResource("7_0f6i3")
 SelectableButton/styles/pressed = ExtResource("7_0f6i3")
 SmallLabel/base_type = &"Label"

--- a/test/unit/test_button_states.gd
+++ b/test/unit/test_button_states.gd
@@ -1,0 +1,142 @@
+extends GutTest
+
+# Tests button press/hover feedback in the theme (#16). Every interactive state
+# used to point at the same style box, so nothing responded to hover or press.
+#
+# These assert the states are *distinct* rather than checking exact colours, so
+# the look can be retuned without breaking the tests - what matters is that
+# feedback exists at all.
+
+const THEME: Theme = preload("res://assets/themes/main_theme.tres")
+
+
+func _style(state: String, type: String) -> StyleBox:
+	return THEME.get_stylebox(state, type)
+
+
+func _modulate(state: String, type: String) -> Color:
+	var style := _style(state, type)
+	assert_true(style is StyleBoxTexture, "%s/%s is a texture style" % [type, state])
+	return (style as StyleBoxTexture).modulate_color
+
+
+# --- Button ---
+
+
+func test_button_defines_every_interactive_state() -> void:
+	for state in ["normal", "hover", "pressed", "disabled", "focus"]:
+		assert_not_null(_style(state, "Button"), "Button defines a %s style" % state)
+
+
+func test_button_hover_differs_from_normal() -> void:
+	assert_ne(_style("hover", "Button"), _style("normal", "Button"), "hovering changes the button")
+
+
+func test_button_pressed_differs_from_hover_and_normal() -> void:
+	assert_ne(_style("pressed", "Button"), _style("normal", "Button"), "pressing looks different")
+	assert_ne(
+		_style("pressed", "Button"),
+		_style("hover", "Button"),
+		"and differs from merely hovering, so a click reads as a click"
+	)
+
+
+func test_button_hover_is_brighter_and_pressed_is_darker() -> void:
+	var normal := _modulate("normal", "Button")
+	var hover := _modulate("hover", "Button")
+	var pressed := _modulate("pressed", "Button")
+
+	assert_gt(hover.r, normal.r, "hover lifts the button")
+	assert_lt(pressed.r, normal.r, "pressing pushes it down")
+
+
+func test_button_disabled_is_dimmed_and_faded() -> void:
+	var normal := _modulate("normal", "Button")
+	var disabled := _modulate("disabled", "Button")
+
+	assert_lt(disabled.r, normal.r, "a disabled button is dimmer")
+	assert_lt(disabled.a, normal.a, "and partly transparent")
+
+
+func test_button_focus_does_not_mask_the_state_underneath() -> void:
+	# Godot draws the focus style over the state style. An opaque focus box would
+	# hide hover and press feedback on the button you just clicked, which is
+	# exactly what used to happen here.
+	var focus := _style("focus", "Button")
+
+	assert_true(focus is StyleBoxFlat, "focus is a flat box, so it can be a ring")
+	assert_false(
+		(focus as StyleBoxFlat).draw_center, "the focus ring has no fill, so it masks nothing"
+	)
+	assert_gt(
+		(focus as StyleBoxFlat).border_width_left, 0, "and it is actually visible as a border"
+	)
+
+
+# --- CheckBox ---
+
+
+func test_checkbox_hover_and_pressed_differ_from_normal() -> void:
+	assert_ne(
+		_style("hover", "CheckBox"), _style("normal", "CheckBox"), "checkbox responds to hover"
+	)
+	assert_ne(_style("pressed", "CheckBox"), _style("normal", "CheckBox"), "and to being pressed")
+
+
+func test_checkbox_focus_does_not_mask_the_state() -> void:
+	var focus := _style("focus", "CheckBox")
+
+	assert_true(focus is StyleBoxFlat, "focus is a flat box")
+	assert_false((focus as StyleBoxFlat).draw_center, "with no fill")
+
+
+# --- OptionButton ---
+
+
+func test_option_button_states_are_distinct() -> void:
+	assert_ne(
+		_style("hover", "OptionButton"),
+		_style("normal", "OptionButton"),
+		"the dropdown responds to hover"
+	)
+	assert_ne(
+		_style("pressed", "OptionButton"), _style("normal", "OptionButton"), "and to being pressed"
+	)
+
+
+func test_option_button_hover_is_lighter_than_pressed() -> void:
+	var hover := (_style("hover", "OptionButton") as StyleBoxFlat).bg_color
+	var pressed := (_style("pressed", "OptionButton") as StyleBoxFlat).bg_color
+
+	assert_gt(hover.v, pressed.v, "hover is lighter than pressed, matching the buttons")
+
+
+# --- SelectableButton ---
+
+
+func test_selectable_button_has_its_own_hover() -> void:
+	# It overrides pressed/focus to show selection, so without its own hover it
+	# would fall back to the plain Button look and clash.
+	assert_ne(
+		_style("hover", "SelectableButton"),
+		_style("hover", "Button"),
+		"the selectable variation hovers in its own style"
+	)
+	assert_ne(
+		_style("hover", "SelectableButton"),
+		_style("pressed", "SelectableButton"),
+		"and hovering is not mistaken for being selected"
+	)
+
+
+# --- Nothing left sharing one style ---
+
+
+func test_no_button_type_reuses_one_style_for_every_state() -> void:
+	for type in ["Button", "CheckBox", "OptionButton"]:
+		var normal := _style("normal", type)
+		var distinct := 0
+		for state in ["hover", "pressed"]:
+			if _style(state, type) != normal:
+				distinct += 1
+		assert_eq(distinct, 2, "%s gives hover and pressed their own styles" % type)

--- a/test/unit/test_button_states.gd.uid
+++ b/test/unit/test_button_states.gd.uid
@@ -1,0 +1,1 @@
+uid://gjqlergffaw0


### PR DESCRIPTION
Advances #16 — the button-feedback half of the juice pass called out in the issue's comment. Broader animation polish across screens stays open there.

## The problem

Every interactive state pointed at the **same style box**:

```
Button/styles/disabled = SubResource("StyleBoxTexture_card")
Button/styles/focus    = SubResource("StyleBoxTexture_card")
Button/styles/hover    = SubResource("StyleBoxTexture_card")
Button/styles/normal   = SubResource("StyleBoxTexture_card")
Button/styles/pressed  = SubResource("StyleBoxTexture_card")
```

Same story for `CheckBox` (six states, one file) and `OptionButton` (five separate style boxes, all the *same colour*). Nothing in the UI responded to being touched.

## What changes

Buttons **lift on hover**, **darken when held**, and **dim and fade when disabled**. Checkboxes and dropdowns get the same treatment. `SelectableButton` gets its own hover, since it overrides pressed and focus to show selection and would otherwise fall back to the plain button look and clash with it.

## Focus had to be fixed first

Godot draws the focus style **over** the state style, and focus was the same opaque card texture. Since clicking leaves a button focused, the button you just clicked would draw its normal look on top of any hover or press styling — making this whole change invisible on exactly the button you were interacting with.

Focus is now a **ring with no fill** (`draw_center = false` plus a border and expand margins), so it marks focus without masking the state underneath. There's a test pinning this specifically, because it's an easy thing to undo by accident.

Also removes four style boxes the change left unreferenced.

## Tests

12 new tests, 190 → 202, all passing. They assert the states are **distinct** rather than checking exact colours, so the look can be retuned freely — what's pinned is that feedback exists:

- Button defines all five states; hover differs from normal; pressed differs from both normal and hover; hover is brighter and pressed darker; disabled is dimmer and partly transparent.
- The focus ring is fill-less and has a visible border, for Button and CheckBox.
- CheckBox and OptionButton hover/pressed differ from normal, and the dropdown's hover is lighter than its pressed.
- SelectableButton hovers in its own style, distinct from both the plain button hover and its own selected look.
- A catch-all asserting no button type reuses one style for every state — the regression that started this.

Mutation-checked: pointing hover and focus back at the shared style fails five assertions.